### PR TITLE
Set parent for child variant before deserializing

### DIFF
--- a/productmd/composeinfo.py
+++ b/productmd/composeinfo.py
@@ -744,6 +744,7 @@ class Variant(VariantBase):
             variant_uids = ["%s-%s" % (self.uid, i) for i in variant_ids]
             for variant_uid in variant_uids:
                 variant = Variant(self._metadata)
+                variant.parent = self
                 variant.deserialize(full_data, variant_uid)
                 self.add(variant)
 
@@ -782,4 +783,3 @@ class Variant(VariantBase):
 
     def add(self, variant):
         VariantBase.add(self, variant)
-        variant.parent = self


### PR DESCRIPTION
When variant is deserialized, validations are run on it. Some of these
validations require that parent is set, otherwise an error is raised. It
is therefore too late to set the parent after the deserialization.