### PR TITLE
add missing image-build formats to producmtd

### DIFF
--- a/productmd/images.py
+++ b/productmd/images.py
@@ -39,10 +39,12 @@ from productmd.composeinfo import Compose
 import six
 
 #: supported image types
-SUPPORTED_IMAGE_TYPES = ["boot", "cd", "docker", "dvd", "ec2", "kvm", "live", "netinst", "p2v", "rescue"]
+SUPPORTED_IMAGE_TYPES = ['boot', 'cd', 'docker', 'dvd', 'ec2', 'kvm', 'live',
+                         'netinst', 'p2v', 'qcow2', 'raw-xz', 'rescue', 'vagrant-libvirt', 'vagrant-virtualbox']
 
 #: supported image formats, they match with file suffix
-SUPPORTED_IMAGE_FORMATS = ["iso", "qcow", "qcow2", "raw", "rhevm.ova", "sda.raw", "tar.gz", "tar.xz", "vdi", "vmdk", "vmx", "vsphere.ova"]
+SUPPORTED_IMAGE_FORMATS = ['iso', 'qcow', 'qcow2', 'raw', 'raw.xz', 'rhevm.ova',
+                           'sda.raw', 'tar.gz', 'tar.xz', 'vagrant-libvirt.box', 'vagrant-virtualbox.box', 'vdi', 'vmdk', 'vmx', 'vsphere.ova']
 
 
 class Images(productmd.common.MetadataBase):


### PR DESCRIPTION
Koji image-build requires some extra formats and suffixes. I personally dislike qcow2 format ... while we used to use kvm ... however koji uses qcow2 so we should as well. 