### PR TITLE
Add Rawhide as valid release version

### DIFF
--- a/doc/terminology.rst
+++ b/doc/terminology.rst
@@ -108,6 +108,12 @@ Recommended schema is dot separated numbers:
 * **X.Y.Z** -- bugfix version / hotfix version
 
 
+.. note ::
+    It is technically possible to use arbitrary string as a version, but this
+    is highly discouraged as it does not allow sorting. If you need it, just
+    start your version with any non-digit character.
+
+
 .. _Milestones:
 
 ==========

--- a/productmd/composeinfo.py
+++ b/productmd/composeinfo.py
@@ -374,8 +374,12 @@ class BaseProduct(productmd.common.MetadataBase):
         self._assert_type("name", list(six.string_types))
 
     def _validate_version(self):
+        """If the version starts with a digit, it must be a sematic-versioning
+        style string.
+        """
         self._assert_type("version", list(six.string_types))
-        self._assert_matches_re("version", [r"^\d+(\.\d+)*$"])
+        if re.match('^\d', self.version):
+            self._assert_matches_re("version", [r"^\d+(\.\d+)*$"])
 
     def _validate_short(self):
         self._assert_type("short", list(six.string_types))

--- a/tests/test_composeinfo.py
+++ b/tests/test_composeinfo.py
@@ -29,7 +29,7 @@ import shutil
 DIR = os.path.dirname(__file__)
 sys.path.insert(0, os.path.join(DIR, ".."))
 
-from productmd.composeinfo import ComposeInfo, Variant
+from productmd.composeinfo import ComposeInfo, Variant, Release
 
 
 class TestComposeInfo(unittest.TestCase):
@@ -116,6 +116,14 @@ class TestComposeInfo(unittest.TestCase):
         # GA is not a valid label; GA is the last RC that is marked as final
         ci.compose.label = "GA"
         self.assertRaises(ValueError, ci.dump, self.ci_path)
+
+    def test_release_non_numeric_version(self):
+        r = Release(None)
+        r.name = "Fedora"
+        r.short = "f"
+        r.version = "Rawhide"
+
+        r.validate()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
On one hand this breaks the assumption that version numbers should be
easily comparable. However, for Fedora Rawhide there is no numeric
version that could be used without confusing people.

Fixes #11 