### PR TITLE
add 'payload' property to images

### DIFF
--- a/doc/images-1.0.rst
+++ b/doc/images-1.0.rst
@@ -40,6 +40,7 @@ in order to read and diff images.json files easily.
                             "implant_md5": <str|null>,  # md5 checksum implanted directly on media (see implantisomd5 and checkisomd5 commands)
                             "mtime": <int>,             # mtime of the image stored as a decimal unix timestamp
                             "path": <str>,              # relative path to the image
+                            "payload": <str>,           # image content (e.g. 'Workstation' or 'KDE')
                             "size": <int>,              # file size of the image
                             "type": <str>,              # see productmd.images.SUPPORTED_IMAGE_TYPES
                             "volume_id": <str|null>     # volume ID; null if not available/applicable

--- a/productmd/images.py
+++ b/productmd/images.py
@@ -119,6 +119,7 @@ class Image(productmd.common.MetadataBase):
         self.checksums = {}             #: (*str*) -- Release name, for example: "Fedora", "Red Hat Enterprise Linux"
         self.implant_md5 = None         #: (*str* or *None*) -- value of implanted md5
         self.bootable = False           #: (*bool=False*) --
+        self.payload = None             #: (*str*) -- image contents, may be same as variant or e.g. 'KDE', 'LXDE'
 
     def _validate_path(self):
         self._assert_type("path", list(six.string_types))
@@ -166,6 +167,10 @@ class Image(productmd.common.MetadataBase):
     def _validate_bootable(self):
         self._assert_type("bootable", [bool])
 
+    def _validate_payload(self):
+        self._assert_type("payload", list(six.string_types))
+        self._assert_not_blank("payload")
+
     def serialize(self, parser):
         data = parser
         self.validate()
@@ -182,6 +187,7 @@ class Image(productmd.common.MetadataBase):
             "checksums": self.checksums,
             "implant_md5": self.implant_md5,
             "bootable": self.bootable,
+            "payload": self.payload,
         }
         data.append(result)
 
@@ -198,6 +204,7 @@ class Image(productmd.common.MetadataBase):
         self.checksums = data["checksums"]
         self.implant_md5 = data["implant_md5"]
         self.bootable = bool(data["bootable"])
+        self.payload = data["payload"]
         self.validate()
 
     def add_checksum(self, root, checksum_type, checksum_value):

--- a/tests/test_images.py
+++ b/tests/test_images.py
@@ -72,7 +72,7 @@ class TestImages(unittest.TestCase):
         im.compose.respin = 0
 
         i = Image(im)
-        i.path = "Fedora/x86_64/iso/Fedora-20-x86_64-DVD.iso"
+        i.path = "Fedora/x86_64/iso/Fedora-Server-dvd-x86_64-20.iso"
         i.mtime = 1410855216
         i.size = 4603248640
         i.arch = "x86_64"
@@ -80,7 +80,8 @@ class TestImages(unittest.TestCase):
         i.format = "iso"
         i.disc_number = 1
         i.disc_count = 1
-        i.volume_id = "Fedora 20 x86_64"
+        i.volume_id = "Fedora-S-dvd-x86_64-20"
+        i.payload = "Server"
 
         # checksums
         i.add_checksum(root=None, checksum_type="sha256", checksum_value="f2eeed5102b8890e9e6f4b9053717fe73031e699c4b76dc7028749ab66e7f917")
@@ -98,15 +99,16 @@ class TestImages(unittest.TestCase):
         im.add("Fedora", "x86_64", i)
 
         i = Image(im)
-        i.path = "Fedora/x86_64/iso/Fedora-20-x86_64-netinst.iso"
+        i.path = "Fedora/x86_64/iso/Fedora-Server-boot-x86_64-20.iso"
         i.mtime = 1410855243
         i.size = 336592896
         i.arch = "x86_64"
-        i.type = "netinst"
+        i.type = "boot"
         i.format = "iso"
         i.disc_number = 1
         i.disc_count = 1
-        i.volume_id = "Fedora 20 x86_64"
+        i.volume_id = "Fedora-S-boot-x86_64-20"
+        i.payload = "Server"
 
         # checksums
         i.add_checksum(root=None, checksum_type="sha256", checksum_value="376be7d4855ad6281cb139430606a782fd6189dcb01d7b61448e915802cc350f")


### PR DESCRIPTION
This is to solve a problem we have with the Fedora composes.
There are 'Spins' and 'Labs' variants which produce several
live images and ARM appliances with differing content. With the
current metadata, there is no good way to tell the KDE live
image from the Xfce or LXDE live images; the only property
which indicates this is the 'path', but that has lots of other
information in it and is not trivially parseable (as image
names don't really strictly follow the naming policy you
cannot strictly tell what element of the image file name is
the 'payload').

Thus we add a 'payload' property which Pungi will populate as
appropriate. For many images the 'payload' will be the variant,
but for Spins and Labs it will indicate the actual content of
each image.

The image metadata version should probably change with this,
but I couldn't see the right way to do that (surely I don't
just universally bump it to 1, 1 in common.py?) Pungi will
also need a few corresponding changes, I will send a Pagure
PR for those.