### PR TITLE
Add __repr__ to Image class

### DIFF
--- a/productmd/images.py
+++ b/productmd/images.py
@@ -120,6 +120,9 @@ class Image(productmd.common.MetadataBase):
         self.implant_md5 = None         #: (*str* or *None*) -- value of implanted md5
         self.bootable = False           #: (*bool=False*) --
 
+    def __repr__(self):
+        return "<Image:{0.path}:{0.format}:{0.arch}>".format(self)
+
     def _validate_path(self):
         self._assert_type("path", list(six.string_types))
         self._assert_not_blank("path")

--- a/tests/test_images.py
+++ b/tests/test_images.py
@@ -133,6 +133,27 @@ class TestImages(unittest.TestCase):
         # 2 images
         self.assertEqual(len(im["Fedora"]["x86_64"]), 2)
 
+    def test_image_repr(self):
+        i = Image(None)
+        i.path = "Fedora/x86_64/iso/Fedora-20-x86_64-DVD.iso"
+        i.mtime = 1410855216
+        i.size = 4603248640
+        i.arch = "x86_64"
+        i.type = "dvd"
+        i.format = "iso"
+        i.disc_number = 1
+        i.disc_count = 1
+        i.volume_id = "Fedora 20 x86_64"
+
+        self.assertEqual(
+            repr(i),
+            '<Image:Fedora/x86_64/iso/Fedora-20-x86_64-DVD.iso:iso:x86_64>')
+
+    def test_image_repr_incomplete(self):
+        i = Image(None)
+
+        self.assertEqual(repr(i), '<Image:None:None:None>')
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
This helps with debugging during development as Images are now printed
not just as memory location, but with a representation that includes
path, format and arch.