### PR TITLE
Correct release validation and update test suite to match reality

### DIFF
--- a/productmd/common.py
+++ b/productmd/common.py
@@ -195,7 +195,8 @@ class Header(MetadataBase):
 
     def _validate_version(self):
         self._assert_type("version", six.string_types)
-        self._assert_matches_re("version", [r"^\d+\.\d+$"])
+        if re.match('^\d', self.version):
+            self._assert_matches_re("version", [r"^\d+(\.\d+)*$"])
 
     @property
     def version_tuple(self):

--- a/tests/test_header.py
+++ b/tests/test_header.py
@@ -40,17 +40,17 @@ class TestHeader(unittest.TestCase):
         self.assertRaises(TypeError, hdr.validate)
 
         # invalid version
-        hdr.version = "first"
-        self.assertRaises(ValueError, hdr.validate)
-
         hdr.version = "1.alpha2"
         self.assertRaises(ValueError, hdr.validate)
 
-        hdr.version = "1"
-        self.assertRaises(ValueError, hdr.validate)
-
         # valid version
+        hdr.version = "1"
+        hdr.validate()
+
         hdr.version = "1.22"
+        hdr.validate()
+
+        hdr.version = "first"
         hdr.validate()
 
     def test_deserialize(self):


### PR DESCRIPTION
There is three locations that do release validation. the two others
were updated to allow for release versions starting with strings.
The third and test suite was not, as a result the test suite says
valid versions are invalid.

Signed-off-by: Dennis Gilmore <dennis@ausil.us>