### PR TITLE
Empty release version is not valid

### DIFF
--- a/productmd/common.py
+++ b/productmd/common.py
@@ -165,10 +165,19 @@ class MetadataBase(object):
             raise ValueError("%s: Field '%s' must not be blank" % (self.__class__.__name__, field))
 
     def _assert_matches_re(self, field, expected_patterns):
+        """
+        The list of patterns can contain either strings or compiled regular
+        expressions.
+        """
         value = getattr(self, field)
         for pattern in expected_patterns:
-            if re.match(pattern, value):
-                return
+            try:
+                if pattern.match(value):
+                    return
+            except AttributeError:
+                # It's not a compiled regex, treat it as string.
+                if re.match(pattern, value):
+                    return
         raise ValueError("%s: Field '%s' has invalid value: %s. It does not match any provided REs: %s"
                          % (self.__class__.__name__, field, value, expected_patterns))
 

--- a/productmd/composeinfo.py
+++ b/productmd/composeinfo.py
@@ -28,7 +28,7 @@ product information, variants, architectures and paths.
 import re
 
 import productmd.common
-from productmd.common import Header
+from productmd.common import Header, RELEASE_VERSION_RE
 
 import six
 
@@ -381,8 +381,7 @@ class BaseProduct(productmd.common.MetadataBase):
         style string.
         """
         self._assert_type("version", list(six.string_types))
-        if re.match('^\d', self.version):
-            self._assert_matches_re("version", [r"^\d+(\.\d+)*$"])
+        self._assert_matches_re("version", [RELEASE_VERSION_RE])
 
     def _validate_short(self):
         self._assert_type("short", list(six.string_types))

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -64,6 +64,8 @@ class TestRelease(unittest.TestCase):
         self.assertFalse(is_valid_release_version("1.a"))
         self.assertFalse(is_valid_release_version("1.1a"))
 
+        self.assertFalse(is_valid_release_version(""))
+
         self.assertFalse(is_valid_release_version("1."))
         self.assertFalse(is_valid_release_version("1.."))
         self.assertFalse(is_valid_release_version("1.1."))

--- a/tests/test_composeinfo.py
+++ b/tests/test_composeinfo.py
@@ -127,6 +127,15 @@ class TestComposeInfo(unittest.TestCase):
 
         r.validate()
 
+    def test_release_empty_version(self):
+        r = Release(None)
+        r.name = "Fedora"
+        r.short = "f"
+        r.version = ""
+        r.type = "ga"
+
+        self.assertRaises(ValueError, r.validate)
+
     def test_create_variants_with_dash(self):
         ci = ComposeInfo()
         ci.release.name = "Fedora"


### PR DESCRIPTION
Reuse the same regular expression used in standalone function to
validate version in release metadata field. Original validation did not
catch empty string as invalid version.