### PR TITLE
Add documentation link to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@ ProductMD
 =========
 
 [![Build Status](https://travis-ci.org/release-engineering/productmd.svg?branch=master)](https://travis-ci.org/release-engineering/productmd)
+[![Documentation Status](https://readthedocs.org/projects/productmd/badge/?version=latest)](http://productmd.readthedocs.io/en/latest/?badge=latest)
 
 ProductMD is a Python library providing parsers for metadata related to composes and installation media.
 


### PR DESCRIPTION
I set up a Read The Docs page for productmd, that will automatically update whenever something changes in `master`. It also hosts rendered documentation for all tagged version of the library and allows downloads in different formats.

This pull request adds a badge to README pointing to latest documentation (from `master` branch).