### PR TITLE
Refactor opening files

### DIFF
--- a/productmd/treeinfo.py
+++ b/productmd/treeinfo.py
@@ -51,13 +51,12 @@ VARIANT_TYPES = [
 
 def compute_checksum(path, checksum_type):
     checksum = hashlib.new(checksum_type)
-    fo = open(path, "rb")
-    while True:
-        chunk = fo.read(1024**2)
-        if not chunk:
-            break
-        checksum.update(chunk)
-    fo.close()
+    with open(path, "rb") as fo:
+        while True:
+            chunk = fo.read(1024**2)
+            if not chunk:
+                break
+            checksum.update(chunk)
     return checksum.hexdigest().lower()
 
 

--- a/tests/test_composeinfo.py
+++ b/tests/test_composeinfo.py
@@ -47,11 +47,9 @@ class TestComposeInfo(unittest.TestCase):
 
     def assertSameFiles(self, path1, path2):
         self.assertEqual(os.path.getsize(path1), os.path.getsize(path2))
-        file1 = open(path1, "r")
-        file2 = open(path2, "r")
-        self.assertEqual(file1.read(), file2.read())
-        file1.close()
-        file2.close()
+        with open(path1, "r") as file1:
+            with open(path2, "r") as file2:
+                self.assertEqual(file1.read(), file2.read())
 
     def _test_identity(self, ci):
         first = os.path.join(self.tmp_dir, "first")

--- a/tests/test_discinfo.py
+++ b/tests/test_discinfo.py
@@ -59,11 +59,9 @@ class TestDiscInfo(unittest.TestCase):
 
     def assertSameFiles(self, path1, path2):
         self.assertEqual(os.path.getsize(path1), os.path.getsize(path2))
-        file1 = open(path1, "r")
-        file2 = open(path2, "r")
-        self.assertEqual(file1.read(), file2.read())
-        file1.close()
-        file2.close()
+        with open(path1, "r") as file1:
+            with open(path2, "r") as file2:
+                self.assertEqual(file1.read(), file2.read())
 
     def _test_identity(self, di):
         first = os.path.join(self.tmp_dir, "first")

--- a/tests/test_images.py
+++ b/tests/test_images.py
@@ -42,11 +42,9 @@ class TestImages(unittest.TestCase):
 
     def assertSameFiles(self, path1, path2):
         self.assertEqual(os.path.getsize(path1), os.path.getsize(path2))
-        file1 = open(path1, "r")
-        file2 = open(path2, "r")
-        self.assertEqual(file1.read(), file2.read())
-        file1.close()
-        file2.close()
+        with open(path1, "r") as file1:
+            with open(path2, "r") as file2:
+                self.assertEqual(file1.read(), file2.read())
 
     def _test_identity(self, im):
         first = os.path.join(self.tmp_dir, "first")

--- a/tests/test_rpms.py
+++ b/tests/test_rpms.py
@@ -42,11 +42,9 @@ class TestRpms(unittest.TestCase):
 
     def assertSameFiles(self, path1, path2):
         self.assertEqual(os.path.getsize(path1), os.path.getsize(path2))
-        file1 = open(path1, "r")
-        file2 = open(path2, "r")
-        self.assertEqual(file1.read(), file2.read())
-        file1.close()
-        file2.close()
+        with open(path1, "r") as file1:
+            with open(path2, "r") as file2:
+                self.assertEqual(file1.read(), file2.read())
 
     def _test_identity(self, rm):
         first = os.path.join(self.tmp_dir, "first")

--- a/tests/test_treeinfo.py
+++ b/tests/test_treeinfo.py
@@ -47,11 +47,9 @@ class TestTreeInfo(unittest.TestCase):
 
     def assertSameFiles(self, path1, path2):
         self.assertEqual(os.path.getsize(path1), os.path.getsize(path2))
-        file1 = open(path1, "r")
-        file2 = open(path2, "r")
-        self.assertEqual(file1.read(), file2.read())
-        file1.close()
-        file2.close()
+        with open(path1, "r") as file1:
+            with open(path2, "r") as file2:
+                self.assertEqual(file1.read(), file2.read())
 
     def _test_identity(self, ti):
         first = os.path.join(self.tmp_dir, "first")
@@ -232,7 +230,8 @@ class TestTreeInfo(unittest.TestCase):
 
     def test_treeinfo_compute_checksum(self):
         tmp_file = os.path.join(self.tmp_dir, "file")
-        open(tmp_file, "w").write("test")
+        with open(tmp_file, "w") as f:
+            f.write("test")
         expected_checksum = "9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08"
         ti = TreeInfo()
         ti.checksums.add("file", "sha256", None, self.tmp_dir)


### PR DESCRIPTION
Always open files using with statement: This makes the code shorter (due to not needing explicit `close()` call), more resilient to exception handling and it gets rid of `ResourceWarnings` on Python 3.

Duplicated code in `common.py` is factored out into a separate function. There is a difference in functionality: if an exception is raised inside the functions, new code will always correctly close the file.