### PR TITLE
Add base product type to compose id

### DIFF
--- a/productmd/composeinfo.py
+++ b/productmd/composeinfo.py
@@ -135,11 +135,12 @@ class ComposeInfo(productmd.common.MetadataBase):
         return self.get_release_id()
 
     def create_compose_id(self):
-        result = "%s-%s" % (self.release.short, self.release.version)
-        if self.release.type and self.release.type.lower() != "ga":
-            result += "-%s" % self.release.type.lower()
+        result = "%s-%s%s" % (self.release.short, self.release.version,
+                              self.release.type_suffix)
         if self.release.is_layered:
-            result += "-%s-%s" % (self.base_product.short, self.base_product.version)
+            result += "-%s-%s%s" % (self.base_product.short,
+                                    self.base_product.version,
+                                    self.base_product.type_suffix)
 
         rhel5 = (self.release.short == "RHEL" and self.release.major_version == "5")
         rhel5 &= (self.base_product.short == "RHEL" and self.base_product.major_version == "5")
@@ -401,6 +402,13 @@ class BaseProduct(productmd.common.MetadataBase):
         if self.version is None:
             return None
         return productmd.common.get_minor_version(self.version)
+
+    @property
+    def type_suffix(self):
+        """This is used in compose ID."""
+        if not self.type or self.type.lower() == 'ga':
+            return ''
+        return '-%s' % self.type.lower()
 
     def serialize(self, data):
         self.validate()

--- a/tests/test_composeinfo.py
+++ b/tests/test_composeinfo.py
@@ -171,5 +171,83 @@ class TestComposeInfo(unittest.TestCase):
         return ci
 
 
+class TestCreateComposeID(unittest.TestCase):
+    def setUpRelease(self, compose_type, release_type, bp_type=None):
+        self.ci = ComposeInfo()
+        self.ci.release.name = 'Fedora'
+        self.ci.release.short = 'F'
+        self.ci.release.version = '22'
+        self.ci.release.type = release_type
+        self.ci.compose.date = '20160622'
+        self.ci.compose.respin = 0
+        self.ci.compose.type = compose_type
+
+        if bp_type:
+            self.ci.release.is_layered = True
+            self.ci.base_product.short = 'BASE'
+            self.ci.base_product.version = '3'
+            self.ci.base_product.type = bp_type
+
+    def test_ga_compose_ga_release(self):
+        self.setUpRelease('production', 'ga')
+        self.assertEqual(self.ci.create_compose_id(),
+                         'F-22-20160622.0')
+
+    def test_nightly_compose_ga_release(self):
+        self.setUpRelease('nightly', 'ga')
+        self.assertEqual(self.ci.create_compose_id(),
+                         'F-22-20160622.n.0')
+
+    def test_ga_compose_updates_release(self):
+        self.setUpRelease('production', 'updates')
+        self.assertEqual(self.ci.create_compose_id(),
+                         'F-22-updates-20160622.0')
+
+    def test_nightly_compose_updates_release(self):
+        self.setUpRelease('nightly', 'updates')
+        self.assertEqual(self.ci.create_compose_id(),
+                         'F-22-updates-20160622.n.0')
+
+    def test_ga_compose_ga_layered_release(self):
+        self.setUpRelease('production', 'ga', 'ga')
+        self.assertEqual(self.ci.create_compose_id(),
+                         'F-22-BASE-3-20160622.0')
+
+    def test_nightly_compose_ga_layered_release(self):
+        self.setUpRelease('nightly', 'ga', 'ga')
+        self.assertEqual(self.ci.create_compose_id(),
+                         'F-22-BASE-3-20160622.n.0')
+
+    def test_ga_compose_updates_layered_release(self):
+        self.setUpRelease('production', 'updates', 'ga')
+        self.assertEqual(self.ci.create_compose_id(),
+                         'F-22-updates-BASE-3-20160622.0')
+
+    def test_nightly_compose_updates_layered_release(self):
+        self.setUpRelease('nightly', 'updates', 'ga')
+        self.assertEqual(self.ci.create_compose_id(),
+                         'F-22-updates-BASE-3-20160622.n.0')
+
+    def test_ga_compose_ga_layered_release_updates_base(self):
+        self.setUpRelease('production', 'ga', 'updates')
+        self.assertEqual(self.ci.create_compose_id(),
+                         'F-22-BASE-3-updates-20160622.0')
+
+    def test_nightly_compose_ga_layered_release_updates_base(self):
+        self.setUpRelease('nightly', 'ga', 'updates')
+        self.assertEqual(self.ci.create_compose_id(),
+                         'F-22-BASE-3-updates-20160622.n.0')
+
+    def test_ga_compose_updates_layered_release_updates_base(self):
+        self.setUpRelease('production', 'updates', 'updates')
+        self.assertEqual(self.ci.create_compose_id(),
+                         'F-22-updates-BASE-3-updates-20160622.0')
+
+    def test_nightly_compose_updates_layered_release_updates_base(self):
+        self.setUpRelease('nightly', 'updates', 'updates')
+        self.assertEqual(self.ci.create_compose_id(),
+                         'F-22-updates-BASE-3-updates-20160622.n.0')
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
The compose ID already contains release type (if it is different than `ga`). This commit adds base product type in the same format. There are also tests for generating the id.