### PR TITLE
Various minor fixes

### DIFF
--- a/productmd/common.py
+++ b/productmd/common.py
@@ -94,11 +94,11 @@ def parse_nvra(nvra):
 
 
 #: Validation regex for release short name: [a-z] followed by [a-z0-9] separated with dashes.
-RELEASE_SHORT_RE = re.compile("^[a-z]+([a-z0-9]*-?[a-z0-9]+)*$")
+RELEASE_SHORT_RE = re.compile(r"^[a-z]+([a-z0-9]*-?[a-z0-9]+)*$")
 
 
 #: Validation regex for release version: any string or [0-9] separated with dots.
-RELEASE_VERSION_RE = re.compile("^([^0-9].*|([0-9]+(\.?[0-9]+)*))$")
+RELEASE_VERSION_RE = re.compile(r"^([^0-9].*|([0-9]+(\.?[0-9]+)*))$")
 
 
 #: Supported release types.

--- a/productmd/common.py
+++ b/productmd/common.py
@@ -480,7 +480,7 @@ class SortedConfigParser(ConfigParser):
             ConfigParser.__init__(self, *args, **kwargs)
         else:
             kwargs["dict_type"] = SortedDict
-            super(ConfigParser, self).__init__(*args, **kwargs)
+            super(SortedConfigParser, self).__init__(*args, **kwargs)
         self.seen = set()
 
     def optionxform(self, optionstr):

--- a/productmd/treeinfo.py
+++ b/productmd/treeinfo.py
@@ -170,7 +170,7 @@ class BaseProduct(productmd.common.MetadataBase):
 
     def _validate_version(self):
         self._assert_type("version", list(six.string_types))
-        if re.match('^\d', self.version):
+        if re.match(r'^\d', self.version):
             self._assert_matches_re("version", [r"^\d+(\.\d+)*$"])
 
     def _validate_short(self):


### PR DESCRIPTION
Mark regexes as raw strings; call `super` correctly on Python 3.