### PR TITLE
Allow importing major classes directly from productmd

### DIFF
--- a/productmd/__init__.py
+++ b/productmd/__init__.py
@@ -1,0 +1,24 @@
+# -*- coding: utf-8 -*-
+
+# Copyright (C) 2015  Red Hat, Inc.
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program.  If not, see
+# <http://www.gnu.org/licenses/>.
+
+from .compose import Compose            # noqa
+from .composeinfo import ComposeInfo    # noqa
+from .discinfo import DiscInfo          # noqa
+from .images import Images              # noqa
+from .rpms import Rpms                  # noqa
+from .treeinfo import TreeInfo          # noqa


### PR DESCRIPTION
This should simplify things for most users: just import productmd module and Compose (the one for metadata loading), Rpms and Images classes are directly available.

Please note that I changed the copyright header to not include FSF address (that seems to be the recommended wording: https://www.gnu.org/licenses/gpl-howto.html).