### PR TITLE
Add rpm-ostree image type

### DIFF
--- a/productmd/images.py
+++ b/productmd/images.py
@@ -40,8 +40,12 @@ __all__ = (
 
 
 #: supported image types
-SUPPORTED_IMAGE_TYPES = ['boot', 'cd', 'docker', 'dvd', 'ec2', 'kvm', 'live',
-                         'netinst', 'p2v', 'qcow2', 'raw-xz', 'rescue', 'vagrant-libvirt', 'vagrant-virtualbox']
+SUPPORTED_IMAGE_TYPES = ['boot', 'cd', 'docker', 'dvd',
+                         # installer image that deploys a payload containing an
+                         # ostree-based distribution
+                         'dvd-ostree',
+                         'ec2', 'kvm', 'live', 'netinst', 'p2v', 'qcow2', 'raw-xz',
+                         'rescue', 'vagrant-libvirt', 'vagrant-virtualbox']
 
 #: supported image formats, they match with file suffix
 SUPPORTED_IMAGE_FORMATS = ['iso', 'qcow', 'qcow2', 'raw', 'raw.xz', 'rhevm.ova',


### PR DESCRIPTION
It describes an installer image that deploys a payload containing an
ostree-based distribution.

See https://pagure.io/pungi/issue/417 for reference.