### PR TITLE
Add unified flag for images

### DIFF
--- a/productmd/images.py
+++ b/productmd/images.py
@@ -140,6 +140,7 @@ class Image(productmd.common.MetadataBase):
         self.implant_md5 = None         #: (*str* or *None*) -- value of implanted md5
         self.bootable = False           #: (*bool=False*) --
         self.subvariant = None          #: (*str*) -- image contents, may be same as variant or e.g. 'KDE', 'LXDE'
+        self.unified = False            #: (*bool=False*) -- indicates if the ISO contains content from multiple variants
 
     def __repr__(self):
         return "<Image:{0.path}:{0.format}:{0.arch}>".format(self)
@@ -193,6 +194,9 @@ class Image(productmd.common.MetadataBase):
     def _validate_subvariant(self):
         self._assert_type("subvariant", list(six.string_types))
 
+    def _validate_unified(self):
+        self._assert_type("unified", [bool])
+
     def serialize(self, parser):
         data = parser
         self.validate()
@@ -211,6 +215,9 @@ class Image(productmd.common.MetadataBase):
             "bootable": self.bootable,
             "subvariant": self.subvariant,
         }
+        if self.unified:
+            # Only add the `unified` field if it doesn't have the default value.
+            result['unified'] = self.unified
         data.append(result)
 
     def deserialize(self, data):
@@ -231,6 +238,7 @@ class Image(productmd.common.MetadataBase):
         else:
             # 1.1+
             self.subvariant = data["subvariant"]
+        self.unified = data.get('unified', False)
         self.validate()
 
     def add_checksum(self, root, checksum_type, checksum_value):

--- a/tests/test_images.py
+++ b/tests/test_images.py
@@ -273,6 +273,55 @@ class TestImages(unittest.TestCase):
         im.dump(converted)
         self.assertSameFiles(converted, after)
 
+    def test_unified_iso_serialized_only_with_true(self):
+        i = Image(None)
+        i.arch = 'x86_64'
+        i.disc_count = 1
+        i.disc_number = 1
+        i.format = 'iso'
+        i.type = 'dvd'
+        i.mtime = 1410855216
+        i.path = "Fedora/x86_64/iso/Fedora-20-x86_64-DVD.iso"
+        i.size = 4603248640
+        i.subvariant = 'Workstation'
+        i.checksums = {'sha256': 'XXXXXX'}
+
+        data = []
+        i.serialize(data)
+        self.assertFalse('unified' in data[0])
+
+        i.unified = True
+        data = []
+        i.serialize(data)
+        self.assertTrue(data[0]['unified'])
+
+    def test_unified_iso_deserialize(self):
+        im = Images()
+        i = Image(im)
+
+        data = {
+            'arch': 'x86_64',
+            'disc_count': 1,
+            'disc_number': 1,
+            'format': 'iso',
+            'type': 'dvd',
+            'mtime': 1410855216,
+            'path': "Fedora/x86_64/iso/Fedora-20-x86_64-DVD.iso",
+            'size': 4603248640,
+            'subvariant': 'Workstation',
+            'volume_id': None,
+            'implant_md5': None,
+            'bootable': True,
+            'checksums': {'sha256': 'XXXXXX'},
+        }
+
+        i.deserialize(data)
+        self.assertFalse(i.unified)
+
+        data['unified'] = True
+        i.deserialize(data)
+        self.assertTrue(i.unified)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
The default value is `False`. When the metadata is serialized, the field is only added when the flag is set to `True`.