### PR TITLE
Add new compose type: ci.

### DIFF
--- a/productmd/composeinfo.py
+++ b/productmd/composeinfo.py
@@ -50,9 +50,10 @@ if six.PY3:
 # least important come first
 #: supported compose types
 COMPOSE_TYPES = [
-    "test",
-    "nightly",
-    "production",
+    "test",             # for test purposes only
+    "ci",               # continuous integration, frequently from an automatically generated package set
+    "nightly",          # nightly composes from production package set
+    "production",       # production composes
 ]
 
 
@@ -259,7 +260,7 @@ class Compose(productmd.common.MetadataBase):
     def _validate_id(self):
         self._assert_type("id", list(six.string_types))
         self._assert_not_blank("id")
-        self._assert_matches_re("id", [r".*\d{8}(\.nightly|\.n|\.test|\.t)?(\.\d+)?"])
+        self._assert_matches_re("id", [r".*\d{8}(\.nightly|\.n|\.ci|\.test|\.t)?(\.\d+)?"])
 
     def _validate_date(self):
         self._assert_type("date", list(six.string_types))
@@ -309,6 +310,8 @@ class Compose(productmd.common.MetadataBase):
     def type_suffix(self):
         if self.type == "production":
             return ""
+        if self.type == "ci":
+            return ".ci"
         if self.type == "nightly":
             return ".n"
         if self.type == "test":

--- a/tests/test_composeinfo.py
+++ b/tests/test_composeinfo.py
@@ -198,6 +198,11 @@ class TestCreateComposeID(unittest.TestCase):
         self.assertEqual(self.ci.create_compose_id(),
                          'F-22-20160622.n.0')
 
+    def test_ci_compose_ga_release(self):
+        self.setUpRelease('ci', 'ga')
+        self.assertEqual(self.ci.create_compose_id(),
+                         'F-22-20160622.ci.0')
+
     def test_ga_compose_updates_release(self):
         self.setUpRelease('production', 'updates')
         self.assertEqual(self.ci.create_compose_id(),


### PR DESCRIPTION
The 'ci' compose type is for composes created as part of continuous integration.
These are frequently created from an automatically generated package set.