### PR TITLE
setup.py: include requirements

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,6 +21,10 @@ for package_root_dir in package_root_dirs:
             packages.add(root.replace("/", "."))
 packages = sorted(packages)
 
+# Manage dependencies in requirements.txt
+with open('requirements.txt') as f:
+    reqs = f.read().splitlines()
+
 
 setup(
     name            = "productmd",
@@ -34,4 +38,5 @@ setup(
     packages        = packages,
     scripts         = [],
     test_suite      = "tests",
+    install_requires=reqs,
 )


### PR DESCRIPTION
Prior to this change, commands such as `pip install productmd` or `python setup.py develop` would not ensure that the "six" library was present.

Parse the requirements file so that we ensure that all dependencies are installed.