### PR TITLE
tests: add test for accessing composes over HTTP

### DIFF
--- a/productmd/common.py
+++ b/productmd/common.py
@@ -162,7 +162,9 @@ def _open_file_obj(f, mode="r"):
     """
     if isinstance(f, six.string_types):
         if f.startswith(("http://", "https://")):
-            context = ssl._create_unverified_context()
+            context = None  # py26, py33, py34
+            if hasattr(ssl, '_create_unverified_context'):
+                context = ssl._create_unverified_context()
             file_obj = six.moves.urllib.request.urlopen(f, context=context)
             yield file_obj
             file_obj.close()
@@ -175,7 +177,9 @@ def _open_file_obj(f, mode="r"):
 
 def _file_exists(path):
     if path.startswith(("http://", "https://")):
-        context = ssl._create_unverified_context()
+        context = None  # py26, py33, py34
+        if hasattr(ssl, '_create_unverified_context'):
+            context = ssl._create_unverified_context()
         try:
             file_obj = six.moves.urllib.request.urlopen(path, context=context)
             file_obj.close()

--- a/tests/compose/composeinfo.json
+++ b/tests/compose/composeinfo.json
@@ -1,0 +1,26 @@
+{
+  "header": {
+    "version": "0.3"
+  },
+  "payload": {
+    "base_product": {
+      "name": "Red Hat Enterprise Linux",
+      "short": "RHEL",
+      "version": "7"
+    },
+    "compose": {
+      "date": "20161110",
+      "id": "MYPRODUCT-2.1-RHEL-7-20161110.t.0",
+      "respin": 0,
+      "type": "test"
+    },
+    "product": {
+      "is_layered": true,
+      "name": "Really Cool Product",
+      "short": "MYPRODUCT",
+      "type": "ga",
+      "version": "2.1"
+    },
+    "variants": {}
+  }
+}


### PR DESCRIPTION
This test exercises the behavior added in 2d1f50df1f6746f690cd31b5c639341e4a47b852

This test uncovered the fact that some Pythons do not have `_ssl_unverified_context()`, and this PR fixes that.