### PR TITLE
Minor fixes to tito and spec

### DIFF
--- a/.tito/releasers.conf
+++ b/.tito/releasers.conf
@@ -1,34 +1,27 @@
 [fedora-rawhide]
 releaser = tito.release.FedoraGitReleaser
 branches = master
-builder.test = 1
 
 [fedora-25]
 releaser = tito.release.FedoraGitReleaser
 branches = f25
-builder.test = 1
 
 [fedora-24]
 releaser = tito.release.FedoraGitReleaser
 branches = f24
-builder.test = 1
 
 [epel-6]
 releaser = tito.release.FedoraGitReleaser
 branches = el6
-builder.test = 1
 
 [epel-7]
 releaser = tito.release.FedoraGitReleaser
 branches = epel7
-builder.test = 1
 
 [rhel-6]
 releaser = tito.release.DistGitReleaser
 branches = eng-rhel-6
-builder.test = 1
 
 [rhel-7]
 releaser = tito.release.DistGitReleaser
 branches = eng-rhel-7
-builder.test = 1

--- a/TITO.md
+++ b/TITO.md
@@ -18,7 +18,6 @@ for example:
     [fedora-rawhide]
     releaser = tito.release.FedoraGitReleaser
     branches = master
-    builder.test = 1
 
 ### Create spec file in the project's root dir.
 Make sure the spec is commited to git to make next steps work.

--- a/python-productmd.spec
+++ b/python-productmd.spec
@@ -1,8 +1,5 @@
 %global with_python3 1
 
-# this must go after all 'License:' tags
-%{!?_licensedir:%global license %doc}
-
 %if 0%{?fedora} && 0%{?fedora} <= 12
 %global with_python3 0
 %endif
@@ -86,6 +83,9 @@ and installation media.
 %if 0%{?with_python3}
 %{__python3} ./setup.py test
 %endif
+
+# this must go after all 'License:' tags
+%{!?_licensedir:%global license %doc}
 
 %files
 %license LICENSE


### PR DESCRIPTION
Remove `builder.test` from releasers because it generates ugly tarball names.
Adjust `%license` definition to have it later.