### PR TITLE
add __version__ attribute

### DIFF
--- a/.tito/templates/__init__.py.in
+++ b/.tito/templates/__init__.py.in
@@ -19,7 +19,7 @@
 # Note this file is templated with Tito. Please make changes to
 # .tito/templates/__init__.py.in in Git.
 
-__version__ = '1.18'
+__version__ = '$version'
 
 from .compose import Compose            # noqa
 from .composeinfo import ComposeInfo    # noqa

--- a/.tito/tito.props
+++ b/.tito/tito.props
@@ -3,3 +3,7 @@ builder = tito.builder.Builder
 tagger = tito.tagger.VersionTagger
 changelog_do_not_remove_cherrypick = 0
 changelog_format = %s (%ae)
+
+[version_template]
+destination_file = productmd/__init__.py
+template_file = .tito/templates/__init__.py.in


### PR DESCRIPTION
This attribute is described at https://www.python.org/dev/peps/pep-0396/

This allows productmd consumers to report the exact version of productmd
that is in use, or conditionalize consumer behavior based on this
version number, etc.

We can use this attribute in setup.py, rather than hard-coding it there.