### PR TITLE
setup.py: add long_description

### DIFF
--- a/productmd/__init__.py
+++ b/productmd/__init__.py
@@ -16,6 +16,8 @@
 # License along with this program.  If not, see
 # <http://www.gnu.org/licenses/>.
 
+__version__ = '1.3'
+
 from .compose import Compose            # noqa
 from .composeinfo import ComposeInfo    # noqa
 from .discinfo import DiscInfo          # noqa

--- a/setup.py
+++ b/setup.py
@@ -3,8 +3,18 @@
 
 
 import os
+import re
 
 from setuptools import setup
+
+
+def read_module_contents():
+    with open('productmd/__init__.py') as installer_init:
+        return installer_init.read()
+
+module_file = read_module_contents()
+metadata = dict(re.findall("__([a-z]+)__\s*=\s*'([^']+)'", module_file))
+version = metadata['version']
 
 
 # recursively scan for python modules to be included
@@ -19,7 +29,7 @@ packages = sorted(packages)
 
 setup(
     name            = "productmd",
-    version         = "1.3",
+    version         = version,
     description     = "Product, compose and installation media metadata library",
     url             = "https://github.com/release-engineering/productmd",
     author          = "Daniel Mach",

--- a/setup.py
+++ b/setup.py
@@ -15,6 +15,7 @@ def read_module_contents():
 module_file = read_module_contents()
 metadata = dict(re.findall("__([a-z]+)__\s*=\s*'([^']+)'", module_file))
 version = metadata['version']
+long_description = open('README.rst').read()
 
 
 # recursively scan for python modules to be included
@@ -34,6 +35,7 @@ setup(
     url             = "https://github.com/release-engineering/productmd",
     author          = "Daniel Mach",
     author_email    = "dmach@redhat.com",
+    long_description=long_description,
     license         = "LGPLv2.1",
 
     packages        = packages,


### PR DESCRIPTION
Store the README contents in our packaging for PyPI. This will cause PyPI to display the contents on the page at https://pypi.python.org/pypi/productmd .