### PR TITLE
composeinfo: fix crashes with get_variants()

### DIFF
--- a/productmd/composeinfo.py
+++ b/productmd/composeinfo.py
@@ -582,7 +582,7 @@ class VariantBase(productmd.common.MetadataBase):
         if "self" in types:
             result.append(self)
 
-        for variant in self.variants.itervalues():
+        for variant in six.itervalues(self.variants):
             if types and variant.type not in types:
                 continue
             if arch and arch not in variant.arches.union(["src"]):

--- a/productmd/composeinfo.py
+++ b/productmd/composeinfo.py
@@ -579,9 +579,6 @@ class VariantBase(productmd.common.MetadataBase):
         types = types or []
         result = []
 
-        if arch and arch not in self.arches + ["src"]:
-            return result
-
         if "self" in types:
             result.append(self)
 

--- a/productmd/composeinfo.py
+++ b/productmd/composeinfo.py
@@ -591,7 +591,7 @@ class VariantBase(productmd.common.MetadataBase):
             if recursive:
                 result.extend(variant.get_variants(types=[i for i in types if i != "self"], recursive=True))
 
-        result.sort(lambda x, y: cmp(x.uid, y.uid))
+        result.sort(key=lambda x: x.uid)
         return result
 
 

--- a/productmd/composeinfo.py
+++ b/productmd/composeinfo.py
@@ -585,7 +585,7 @@ class VariantBase(productmd.common.MetadataBase):
         for variant in self.variants.itervalues():
             if types and variant.type not in types:
                 continue
-            if arch and arch not in variant.arches + ["src"]:
+            if arch and arch not in variant.arches.union(["src"]):
                 continue
             result.append(variant)
             if recursive:

--- a/tests/test_composeinfo.py
+++ b/tests/test_composeinfo.py
@@ -170,6 +170,30 @@ class TestComposeInfo(unittest.TestCase):
         self._test_identity(ci)
         return ci
 
+    def test_get_variants(self):
+        ci = ComposeInfo()
+        ci.release.name = "Fedora"
+        ci.release.short = "F"
+        ci.release.version = "25"
+        ci.release.type = "ga"
+
+        ci.compose.id = "F-25-20150522.0"
+        ci.compose.type = "production"
+        ci.compose.date = "20161225"
+        ci.compose.respin = 0
+
+        variant = Variant(ci)
+        variant.id = "Server"
+        variant.uid = "Server"
+        variant.name = "Server"
+        variant.type = "variant"
+        variant.arches = set(["armhfp", "i386", "x86_64"])
+
+        ci.variants.add(variant)
+        ci.get_variants()
+        self.assertEqual(ci.get_variants(), [variant])
+        self.assertEqual(ci.get_variants(arch='x86_64'), [variant])
+
 
 class TestCreateComposeID(unittest.TestCase):
     def setUpRelease(self, compose_type, release_type, bp_type=None):

--- a/tests/test_composeinfo.py
+++ b/tests/test_composeinfo.py
@@ -83,7 +83,7 @@ class TestComposeInfo(unittest.TestCase):
         variant.uid = "Server"
         variant.name = "Server"
         variant.type = "variant"
-        variant.arches = ["armhfp", "i386", "x86_64"]
+        variant.arches = set(["armhfp", "i386", "x86_64"])
 
         ci.variants.add(variant)
 
@@ -153,7 +153,7 @@ class TestComposeInfo(unittest.TestCase):
         variant.uid = "Server-Tools"
         variant.name = "Tools"
         variant.type = "variant"
-        variant.arches = ["x86_64"]
+        variant.arches = set(["x86_64"])
         ci.variants.add(variant)
         ci.variants["Server-Tools"]
 
@@ -162,7 +162,7 @@ class TestComposeInfo(unittest.TestCase):
         variant.uid = "Workstation-Tools"
         variant.name = "Tools"
         variant.type = "variant"
-        variant.arches = ["x86_64"]
+        variant.arches = set(["x86_64"])
         ci.variants.add(variant)
         ci.variants["Workstation-Tools"]
 


### PR DESCRIPTION
Prior to this change, if a caller specified an `arch` parameter to `ComposeInfo`'s `get_variants()`, productmd would crash with an `AttributeError`, because we were checking the `arches` member on a `VariantBase` object that probably does not have that member defined.

This PR removes the check completely, since this probably never worked.

This removal uncovered another issue with this scenario. Further down, when we check the individual variant's `.arches` set, we add a single element `["src"]` list to the set. This results in:

```
TypeError: unsupported operand type(s) for +: 'set' and 'list'
```

Use the `union()` method to convert the `["src"]` list to a set and then combine them.