### PR TITLE
Add Python 3.6 on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,4 +5,5 @@ python:
     - "3.3"
     - "3.4"
     - "3.5"
+    - "3.6"
 script: "python setup.py test"


### PR DESCRIPTION
Python 3.6 is a thing now and should be used in next Fedora. Let's test for it.