### PR TITLE
Support 'unique image identifier' concept, enforce on 1.1+

### DIFF
--- a/doc/images-1.1.rst
+++ b/doc/images-1.1.rst
@@ -19,6 +19,14 @@ Compose images metadata is stored as a JSON serialized dictionary.
 It's recommended to sort keys alphabetically and use 4 spaces for indentation
 in order to read and diff images.json files easily.
 
+Image Identity
+==============
+
+It is required that the combination of subvariant, type, format, arch and
+disc_number attributes is unique to each image in the compose. This is to
+ensure these attributes can be used to identify 'the same' image across
+composes. This may require including the variant string in the subvariant.
+
 ::
 
     {


### PR DESCRIPTION
I've been doing this sort of ad hoc in Fedora QA tools for a
while; per discussion in https://pagure.io/pungi/issue/525 , it
seemed a good idea to add the concept to productmd. This adds a
constant that declares the combination of subvariant, type,
format, arch and disc number for an image should always be
unique within a compose, allowing us to use it to identify 'the
same' image across multiple composes. An `identify_image`
function is added to `images` that provides a tuple of the
values.

Perhaps more controversially, this is also enforced in the
Images `add` method; adding an image with different checksums
from an existing image but the same unique attributes will raise
a ValueError.

I don't know if you're going to like this exactly as-is, but I figured I'd send in what I've got and we can kick it around. Maybe you can see better ways to do some of this stuff.