### PR TITLE
Add a compose ID parser, tweak short and version rules

### DIFF
--- a/productmd/common.py
+++ b/productmd/common.py
@@ -93,12 +93,12 @@ def parse_nvra(nvra):
     return result
 
 
-#: Validation regex for release short name: [a-z] followed by [a-z0-9] separated with dashes.
-RELEASE_SHORT_RE = re.compile(r"^[a-z]+([a-z0-9]*-?[a-z0-9]+)*$")
+#: Validation regex for release short name: [a-zA-Z] followed by [a-zA-Z0-9] separated with dashes.
+RELEASE_SHORT_RE = re.compile(r"^[a-zA-Z]+([a-zA-Z0-9]*-?[a-zA-Z0-9]+)*$")
 
 
-#: Validation regex for release version: any string or [0-9] separated with dots.
-RELEASE_VERSION_RE = re.compile(r"^([^0-9].*|([0-9]+(\.?[0-9]+)*))$")
+#: Validation regex for release version: 'Rawhide' or [0-9] separated with dots.
+RELEASE_VERSION_RE = re.compile(r"^(Rawhide|[0-9]+(\.?[0-9]+)*)$")
 
 
 #: Supported release types.

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -36,10 +36,10 @@ class TestRelease(unittest.TestCase):
 
     def test_valid_short(self):
         self.assertTrue(is_valid_release_short("f"))
-        self.assertFalse(is_valid_release_short("F"))
+        self.assertTrue(is_valid_release_short("F"))
 
         self.assertTrue(is_valid_release_short("fedora"))
-        self.assertFalse(is_valid_release_short("Fedora"))
+        self.assertTrue(is_valid_release_short("Fedora"))
 
         self.assertTrue(is_valid_release_short("fedora-server"))
         self.assertTrue(is_valid_release_short("fedora-server-23"))
@@ -60,7 +60,10 @@ class TestRelease(unittest.TestCase):
         self.assertTrue(is_valid_release_version("1.0"))
         self.assertTrue(is_valid_release_version("1.1"))
 
-        self.assertTrue(is_valid_release_version("a"))
+        self.assertTrue(is_valid_release_version("Rawhide"))
+        self.assertFalse(is_valid_release_version("rawhide"))
+
+        self.assertFalse(is_valid_release_version("a"))
         self.assertFalse(is_valid_release_version("1.a"))
         self.assertFalse(is_valid_release_version("1.1a"))
 
@@ -70,8 +73,6 @@ class TestRelease(unittest.TestCase):
         self.assertFalse(is_valid_release_version("1.."))
         self.assertFalse(is_valid_release_version("1.1."))
         self.assertFalse(is_valid_release_version("1..1"))
-
-        self.assertTrue(is_valid_release_version("rawhide"))
 
     def test_split_version(self):
         self.assertEqual(split_version("0"), [0])

--- a/tests/test_composeinfo.py
+++ b/tests/test_composeinfo.py
@@ -29,7 +29,7 @@ import shutil
 DIR = os.path.dirname(__file__)
 sys.path.insert(0, os.path.join(DIR, ".."))
 
-from productmd.composeinfo import ComposeInfo, Variant, Release  # noqa
+from productmd.composeinfo import ComposeInfo, Variant, Release, parse_compose_id  # noqa
 
 
 class TestComposeInfo(unittest.TestCase):
@@ -193,6 +193,200 @@ class TestComposeInfo(unittest.TestCase):
         ci.get_variants()
         self.assertEqual(ci.get_variants(), [variant])
         self.assertEqual(ci.get_variants(arch='x86_64'), [variant])
+
+    def test_parse_compose_id(self):
+        assert parse_compose_id('F-22-20160622.0') == {
+            'short': 'F',
+            'version': '22',
+            'version_type': 'ga',
+            'bp_short': '',
+            'bp_version': '',
+            'bp_type': '',
+            'variant': '',
+            'date': '20160622',
+            'compose_type': 'production',
+            'respin': 0
+        }
+        assert parse_compose_id('F-22-20160622.n.0') == {
+            'short': 'F',
+            'version': '22',
+            'version_type': 'ga',
+            'bp_short': '',
+            'bp_version': '',
+            'bp_type': '',
+            'variant': '',
+            'date': '20160622',
+            'compose_type': 'nightly',
+            'respin': 0
+        }
+        assert parse_compose_id('F-22-20160622.ci.0') == {
+            'short': 'F',
+            'version': '22',
+            'version_type': 'ga',
+            'bp_short': '',
+            'bp_version': '',
+            'bp_type': '',
+            'variant': '',
+            'date': '20160622',
+            'compose_type': 'ci',
+            'respin': 0
+        }
+        assert parse_compose_id('F-22-20160622.t.1') == {
+            'short': 'F',
+            'version': '22',
+            'version_type': 'ga',
+            'bp_short': '',
+            'bp_version': '',
+            'bp_type': '',
+            'variant': '',
+            'date': '20160622',
+            'compose_type': 'test',
+            'respin': 1
+        }
+        assert parse_compose_id('F-22-updates-20160622.0') == {
+            'short': 'F',
+            'version': '22',
+            'version_type': 'updates',
+            'bp_short': '',
+            'bp_version': '',
+            'bp_type': '',
+            'variant': '',
+            'date': '20160622',
+            'compose_type': 'production',
+            'respin': 0
+        }
+        assert parse_compose_id('F-22-updates-20160622.n.0') == {
+            'short': 'F',
+            'version': '22',
+            'version_type': 'updates',
+            'bp_short': '',
+            'bp_version': '',
+            'bp_type': '',
+            'variant': '',
+            'date': '20160622',
+            'compose_type': 'nightly',
+            'respin': 0
+        }
+        assert parse_compose_id('F-22-BASE-3-20160622.0') == {
+            'short': 'F',
+            'version': '22',
+            'version_type': 'ga',
+            'bp_short': 'BASE',
+            'bp_version': '3',
+            'bp_type': 'ga',
+            'variant': '',
+            'date': '20160622',
+            'compose_type': 'production',
+            'respin': 0
+        }
+        assert parse_compose_id('F-22-BASE-3-20160622.n.0') == {
+            'short': 'F',
+            'version': '22',
+            'version_type': 'ga',
+            'bp_short': 'BASE',
+            'bp_version': '3',
+            'bp_type': 'ga',
+            'variant': '',
+            'date': '20160622',
+            'compose_type': 'nightly',
+            'respin': 0
+        }
+        assert parse_compose_id('F-22-updates-BASE-3-20160622.0') == {
+            'short': 'F',
+            'version': '22',
+            'version_type': 'updates',
+            'bp_short': 'BASE',
+            'bp_version': '3',
+            'bp_type': 'ga',
+            'variant': '',
+            'date': '20160622',
+            'compose_type': 'production',
+            'respin': 0
+        }
+        assert parse_compose_id('F-22-updates-BASE-3-20160622.n.0') == {
+            'short': 'F',
+            'version': '22',
+            'version_type': 'updates',
+            'bp_short': 'BASE',
+            'bp_version': '3',
+            'bp_type': 'ga',
+            'variant': '',
+            'date': '20160622',
+            'compose_type': 'nightly',
+            'respin': 0
+        }
+        assert parse_compose_id('F-22-BASE-3-updates-20160622.0') == {
+            'short': 'F',
+            'version': '22',
+            'version_type': 'ga',
+            'bp_short': 'BASE',
+            'bp_version': '3',
+            'bp_type': 'updates',
+            'variant': '',
+            'date': '20160622',
+            'compose_type': 'production',
+            'respin': 0
+        }
+        assert parse_compose_id('F-22-BASE-3-updates-20160622.n.0') == {
+            'short': 'F',
+            'version': '22',
+            'version_type': 'ga',
+            'bp_short': 'BASE',
+            'bp_version': '3',
+            'bp_type': 'updates',
+            'variant': '',
+            'date': '20160622',
+            'compose_type': 'nightly',
+            'respin': 0
+        }
+        assert parse_compose_id('F-22-updates-BASE-3-updates-20160622.0') == {
+            'short': 'F',
+            'version': '22',
+            'version_type': 'updates',
+            'bp_short': 'BASE',
+            'bp_version': '3',
+            'bp_type': 'updates',
+            'variant': '',
+            'date': '20160622',
+            'compose_type': 'production',
+            'respin': 0
+        }
+        assert parse_compose_id('F-22-updates-BASE-3-updates-20160622.n.0') == {
+            'short': 'F',
+            'version': '22',
+            'version_type': 'updates',
+            'bp_short': 'BASE',
+            'bp_version': '3',
+            'bp_type': 'updates',
+            'variant': '',
+            'date': '20160622',
+            'compose_type': 'nightly',
+            'respin': 0
+        }
+        assert parse_compose_id('Fedora-Rawhide-updates-RHEL-6.3.4-20160513.t.1') == {
+            'short': 'Fedora',
+            'version': 'Rawhide',
+            'version_type': 'updates',
+            'bp_short': 'RHEL',
+            'bp_version': '6.3.4',
+            'bp_type': 'ga',
+            'variant': '',
+            'date': '20160513',
+            'compose_type': 'test',
+            'respin': 1
+        }
+        assert parse_compose_id('rhel-5-updates-Server-20160523.2') == {
+            'short': 'rhel',
+            'version': '5',
+            'version_type': 'updates',
+            'bp_short': '',
+            'bp_version': '',
+            'bp_type': '',
+            'variant': 'Server',
+            'date': '20160523',
+            'compose_type': 'production',
+            'respin': 2
+        }
 
 
 class TestCreateComposeID(unittest.TestCase):


### PR DESCRIPTION
This adds a `parse_compose_id` function to `composeinfo`. It
can parse most compose IDs back into their component parts. As
part of this, we tweak the rules for short names and versions
a little. The `RELEASE_SHORT_RE` regex now allows upper-case
characters, as Fedora has been using these in short names for
some time (only `create_release_id` actually validated short
names, up until now, which is why we hadn't noticed this
inconsistency). The `RELEASE_VERSION_RE` regex now does *not*
allow absolutely any string that doesn't start with a digit to
be used as a version; the only string version allowed is
'Rawhide' (this is the only one that exists in the wild so far
as I know). This is to make it possible to write a sane parser
at all.

We also fix `get_date_type_respin` to work with the new `ci`
type.

We could possibly go further than this and disallow the use of
dashes in short names; if we did that, parsing compose IDs
would become much less difficult and slightly more reliable.
But it would require us to either rename or 'grandfather in'
Fedora's existing short names with dashes in them, which are
Fedora-Atomic, Fedora-Docker and Fedora-Cloud. It would be
reasonably easy to write a parser and regex which special case
those exact names but disallow any other with a dash.

Signed-off-by: Adam Williamson <awilliam@redhat.com>