### PR TITLE
add updates-testing as a valid compose type

### DIFF
--- a/productmd/common.py
+++ b/productmd/common.py
@@ -106,6 +106,7 @@ RELEASE_TYPES = [
     "fast",
     "ga",
     "updates",
+    "updates-testing",
     "eus",
     "aus",
     "els",


### PR DESCRIPTION
Fedora is moving to having bodhi use pungi to do composes for
pushing updates, in order to cover the use cases we need to have
a updates-testing compose in addition to a updates compose type.

Signed-off-by: Dennis Gilmore <dennis@ausil.us>