### PR TITLE
Parse release ID with dash in type

### DIFF
--- a/productmd/common.py
+++ b/productmd/common.py
@@ -473,7 +473,23 @@ def _parse_release_id_part(release_id, prefix=""):
         short, version = release_id.split("-")
         release_type = "ga"
     else:
-        short, version, release_type = release_id.rsplit("-", 2)
+        release_type = None
+        for type_ in RELEASE_TYPES:
+            # Try to find a known release type.
+            if release_id.endswith(type_):
+                release_type = type_
+                break
+
+        if release_type:
+            # Found, remove it from the parsed string (because there could be a
+            # dash causing problems).
+            release_id = release_id[:-len(release_type)]
+
+        short, version, release_type_extracted = release_id.rsplit("-", 2)
+
+        # If known release type is found, use it; otherwise fall back to the
+        # one we parsed out.
+        release_type = release_type or release_type_extracted
     result = {
         "short": short,
         "version": version,

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -27,7 +27,7 @@ import sys
 DIR = os.path.dirname(__file__)
 sys.path.insert(0, os.path.join(DIR, ".."))
 
-from productmd.common import is_valid_release_short, is_valid_release_version  # noqa
+from productmd.common import is_valid_release_short, is_valid_release_version, parse_release_id  # noqa
 from productmd.common import split_version  # noqa
 from productmd.common import create_release_id  # noqa
 
@@ -84,6 +84,29 @@ class TestRelease(unittest.TestCase):
         self.assertEqual(create_release_id("f", "23", "ga"), "f-23")
         self.assertEqual(create_release_id("f", "23", "updates"), "f-23-updates")
         self.assertRaises(ValueError, create_release_id, "f", "23", None)
+
+    def test_parse_release_id(self):
+        expected = {
+            "short": "f",
+            "version": "23",
+            "type": "ga",
+        }
+        self.assertEqual(parse_release_id("f-23-ga"), expected)
+        self.assertEqual(parse_release_id("f-23"), expected)
+
+        expected = {
+            "short": "f",
+            "version": "23",
+            "type": "updates",
+        }
+        self.assertEqual(parse_release_id("f-23-updates"), expected)
+
+        expected = {
+            "short": "f",
+            "version": "23",
+            "type": "updates-testing",
+        }
+        self.assertEqual(parse_release_id("f-23-updates-testing"), expected)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Follow up for #100 that makes the tests pass.

@hluk