### PR TITLE
Allow symbolic release versions

### DIFF
--- a/productmd/common.py
+++ b/productmd/common.py
@@ -98,8 +98,9 @@ def parse_nvra(nvra):
 RELEASE_SHORT_RE = re.compile(r"^[a-z]+([a-z0-9]*-?[a-z0-9]+)*$")
 
 
-#: Validation regex for release version: any string or [0-9] separated with dots.
-RELEASE_VERSION_RE = re.compile(r"^([^0-9].*|([0-9]+(\.?[0-9]+)*))$")
+#: Validation regex for release version: any string, unless it starts with a
+# number, in which case it should be a dotted version string.
+RELEASE_VERSION_RE = re.compile(r"^([^0-9].*|[0-9]+(\.\w+)*)$")
 
 
 #: Validation regex for release type: [a-z] followed by [a-z0-9] separated with dashes.

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -61,8 +61,8 @@ class TestRelease(unittest.TestCase):
         self.assertTrue(is_valid_release_version("1.1"))
 
         self.assertTrue(is_valid_release_version("a"))
-        self.assertFalse(is_valid_release_version("1.a"))
-        self.assertFalse(is_valid_release_version("1.1a"))
+        self.assertTrue(is_valid_release_version("1.a"))
+        self.assertTrue(is_valid_release_version("1.1a"))
 
         self.assertFalse(is_valid_release_version(""))
 


### PR DESCRIPTION
In order to have one compose stream track a development branch from
which release branches are created, it's useful to refer to the
in-development version symbolically (e.g., a `release_version` of `2.y`
would indicate a version 2 development stream from which 2.0, 2.1, …
configuration branches are made.

Perhaps the best description of the change is the patch for
`tests/test_common.py`.