### PR TITLE
common: parse_nvra() doc improvements

### DIFF
--- a/productmd/common.py
+++ b/productmd/common.py
@@ -84,7 +84,7 @@ def parse_nvra(nvra):
 
     :param nvra: N-E:V-R.A string. This can be a file name or a file path including the '.rpm' suffix.
     :type nvra: str
-    :rtype: dict
+    :rtype: dict, with "name", "epoch", "version", "release", and "arch" elements.
     """
     if nvra.endswith(".rpm"):
         nvra = nvra[:-4]

--- a/productmd/common.py
+++ b/productmd/common.py
@@ -82,7 +82,7 @@ def parse_nvra(nvra):
     """
     Parse RPM N-E:V-R.A string to a dict.
 
-    :param nvra: N-E:V-R.A string, eventually a file name or a file path incl. '.rpm' suffix
+    :param nvra: N-E:V-R.A string. This can be a file name or a file path including the '.rpm' suffix.
     :type nvra: str
     :rtype: dict
     """


### PR DESCRIPTION
* Explain that the `nvra` argument *may* be a filename, but this is not    necessary.

* List the exact keys that `parse_nvra()` will return.