### PR TITLE
Allow modules without metadata

### DIFF
--- a/productmd/modules.py
+++ b/productmd/modules.py
@@ -119,10 +119,8 @@ class Modules(productmd.common.MetadataBase):
             if not param:
                 raise ValueError("Non-empty '%s' is expected" % param_name)
 
-        if type(rpms) not in (list, tuple):
+        if not isinstance(rpms, (list, tuple)):
             raise ValueError("Wrong type of 'rpms'")
-        if not rpms:
-            raise ValueError("Empty array 'rpms'")
 
         arches = self.modules.setdefault(variant, {})
         uids = arches.setdefault(arch, {})


### PR DESCRIPTION
Libmodulemd is fine with such modules, and there are a few like this in the wild. We should be able to represent them.