### PR TITLE
Do not use custom repr for objects with no compose

### DIFF
--- a/productmd/composeinfo.py
+++ b/productmd/composeinfo.py
@@ -530,7 +530,10 @@ class VariantBase(productmd.common.MetadataBase):
         self.variants = {}
 
     def __repr__(self):
-        return u'<%s:%s>' % (self.__class__.__name__, self._metadata.compose.id)
+        if hasattr(self, "compose"):
+            return u'<%s:%s>' % (self.__class__.__name__, self._metadata.compose.id)
+        else:
+            return super(VariantBase, self).__repr__()
 
     def __getitem__(self, name):
         # There can be exceptions, like $variant-optional on top-level,


### PR DESCRIPTION
This will fix issue when `TreeInfo` is used in the ipython or other similar debugging tool.

Without this fix the following code in the debugger will crash:

ti = TreeInfo()
ti.load(".treeinfo")
ti.variants