### PR TITLE
Add additional_variants attribute to unified images

### DIFF
--- a/tests/test_images.py
+++ b/tests/test_images.py
@@ -204,12 +204,12 @@ class TestImages(unittest.TestCase):
         })
         self.assertRaises(ValueError, i.add_checksum, root=None, checksum_type="sha256", checksum_value="foo")
         # identifier (Image instance)
-        self.assertEqual(identify_image(i), ("KDE", "live", "iso", "x86_64", 1, False))
+        self.assertEqual(identify_image(i), ("KDE", "live", "iso", "x86_64", 1, False, []))
         # identifier (dict)
         parser = []
         i.serialize(parser)
         imgdict = parser[0]
-        self.assertEqual(identify_image(imgdict), ("KDE", "live", "iso", "x86_64", 1, False))
+        self.assertEqual(identify_image(imgdict), ("KDE", "live", "iso", "x86_64", 1, False, []))
 
         i.implant_md5 = "8bc179ecdd48e0b019365104f081a83e"
         i.bootable = True


### PR DESCRIPTION
A unified image contains packages from multiple variants. It would be really nice to be able to tell based on the metadata what those included variants actually are.

This new attribute is only present in the output metadata if it's not empty, and it can only be set if unified is set to True. We still allow having unified images without this extra information.

The new attribute should be part of unique attributes types (because there could be two different unified images (for example each would bundle a different addon).

CC @AdamWill: would this change break any of your tooling? I'm particularly unsure about how you use the `identify_image` function.