### PR TITLE
get_major_version should always return first component

### DIFF
--- a/productmd/common.py
+++ b/productmd/common.py
@@ -32,6 +32,7 @@ import json
 import codecs
 import contextlib
 import ssl
+import warnings
 
 import six
 from six.moves.configparser import ConfigParser
@@ -384,20 +385,18 @@ def split_version(version):
     return [int(i) for i in version.split(".")]
 
 
-def get_major_version(version, remove=1):
+def get_major_version(version, remove=None):
     """
     Return major version of a provided version string.
 
     :param version: Version string
     :type version: str
-    :param remove: Number of version parts to remove; defaults to 1
-    :type remove: int
     :rtype: str
     """
+    if remove:
+        warnings.warn("remove argument is deprecated", DeprecationWarning)
     version_split = version.split(".")
-    if len(version_split) <= remove:
-        return version
-    return ".".join(version_split[:-remove])
+    return version_split[0]
 
 
 def get_minor_version(version, remove=1):

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -30,6 +30,7 @@ sys.path.insert(0, os.path.join(DIR, ".."))
 from productmd.common import is_valid_release_short, is_valid_release_version, parse_release_id, is_valid_release_type  # noqa
 from productmd.common import split_version  # noqa
 from productmd.common import create_release_id  # noqa
+from productmd.common import get_major_version  # noqa
 
 
 class TestRelease(unittest.TestCase):
@@ -121,6 +122,14 @@ class TestRelease(unittest.TestCase):
             "type": "updates-testing",
         }
         self.assertEqual(parse_release_id("f-23-updates-testing"), expected)
+
+
+class TestGetMajorVersion(unittest.TestCase):
+    def test_two_parts(self):
+        self.assertEqual(get_major_version("1.0"), "1")
+
+    def test_three_parts(self):
+        self.assertEqual(get_major_version("1.0.0"), "1")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
If the version has multiple components, the first number is the major version.