### PR TITLE
Fix extracting minor version from long string

### DIFF
--- a/productmd/common.py
+++ b/productmd/common.py
@@ -386,8 +386,12 @@ def split_version(version):
 
 
 def get_major_version(version, remove=None):
-    """
-    Return major version of a provided version string.
+    """Return major version of a provided version string. Major version is the
+    first component of the dot-separated version string. For non-version-like
+    strings this function returns the argument unchanged.
+
+    The ``remove`` parameter is deprecated since version 1.18 and will be
+    removed in the future.
 
     :param version: Version string
     :type version: str
@@ -399,20 +403,26 @@ def get_major_version(version, remove=None):
     return version_split[0]
 
 
-def get_minor_version(version, remove=1):
-    """
-    Return minor version of a provided version string.
+def get_minor_version(version, remove=None):
+    """Return minor version of a provided version string. Minor version is the
+    second component in the dot-separated version string. For non-version-like
+    strings this function returns ``None``.
+
+    The ``remove`` parameter is deprecated since version 1.18 and will be
+    removed in the future.
 
     :param version: Version string
     :type version: str
-    :param remove: Number of version parts to remove; defaults to 1
-    :type remove: int
     :rtype: str
     """
+    if remove:
+        warnings.warn("remove argument is deprecated", DeprecationWarning)
     version_split = version.split(".")
-    if len(version_split) <= remove:
+    try:
+        # Assume MAJOR.MINOR.REST...
+        return version_split[1]
+    except IndexError:
         return None
-    return ".".join(version_split[-remove:])
 
 
 def create_release_id(short, version, type, bp_short=None, bp_version=None, bp_type=None):

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -30,7 +30,7 @@ sys.path.insert(0, os.path.join(DIR, ".."))
 from productmd.common import is_valid_release_short, is_valid_release_version, parse_release_id, is_valid_release_type  # noqa
 from productmd.common import split_version  # noqa
 from productmd.common import create_release_id  # noqa
-from productmd.common import get_major_version  # noqa
+from productmd.common import get_major_version, get_minor_version  # noqa
 
 
 class TestRelease(unittest.TestCase):
@@ -130,6 +130,20 @@ class TestGetMajorVersion(unittest.TestCase):
 
     def test_three_parts(self):
         self.assertEqual(get_major_version("1.0.0"), "1")
+
+    def test_no_dots(self):
+        self.assertEqual(get_major_version("Rawhide"), "Rawhide")
+
+
+class TestGetMinorVersion(unittest.TestCase):
+    def test_two_parts(self):
+        self.assertEqual(get_minor_version("1.2"), "2")
+
+    def test_three_parts(self):
+        self.assertEqual(get_minor_version("1.2.3"), "2")
+
+    def test_no_dots(self):
+        self.assertEqual(get_minor_version("Rawhide"), None)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
The function does bad things on versions with more than two components. This patch makes it always return a single version component. The `remove` argument is deprecated as it did not serve a useful function.

Fixes: #125