### PR TITLE
treeinfo: add mirrorlist/metalink support

### DIFF
--- a/productmd/composeinfo.py
+++ b/productmd/composeinfo.py
@@ -684,6 +684,8 @@ class VariantPaths(productmd.common.MetadataBase):
         * **os_tree** -- installable tree with binary RPMs, kickstart trees, readme etc.
         * **packages** -- directory with binary RPMs
         * **repository** -- YUM repository with binary RPMs
+        * **mirrorlist** -- YUM mirrorlist for binary RPMs
+        * **metalink** -- YUM metalink for binary RPMs
         * **isos** -- Binary ISOs
         * **jigdos** -- Jigdo files for binary ISOs
 
@@ -692,6 +694,8 @@ class VariantPaths(productmd.common.MetadataBase):
         * **source_tree** -- tree with source RPMs
         * **source_packages** -- directory with source RPMs
         * **source_repository** -- YUM repository with source RPMs
+        * **source_mirrorlist** -- YUM mirrorlist for source RPMs
+        * **source_metalink** -- YUM metalink for source RPMs
         * **source_isos** -- Source ISOs
         * **source_jigdos** -- Jigdo files for source ISOs
 
@@ -700,6 +704,8 @@ class VariantPaths(productmd.common.MetadataBase):
         * **debug_tree** -- tree with debug RPMs
         * **debug_packages** -- directory with debug RPMs
         * **debug_repository** -- YUM repository with debug RPMs
+        * **debug_mirrorlist** -- YUM mirrorlist for debug RPMs
+        * **debug_metalink** -- YUM metalink for debug RPMs
 
     Example::
 
@@ -725,6 +731,8 @@ class VariantPaths(productmd.common.MetadataBase):
             "os_tree",
             "packages",
             "repository",
+            "mirrorlist",
+            "metalink",
             "isos",
             "jigdos",
 
@@ -732,6 +740,8 @@ class VariantPaths(productmd.common.MetadataBase):
             "source_tree",
             "source_packages",
             "source_repository",
+            "source_mirrorlist",
+            "source_metalink",
             "source_isos",
             "source_jigdos",
 
@@ -739,6 +749,8 @@ class VariantPaths(productmd.common.MetadataBase):
             "debug_tree",
             "debug_packages",
             "debug_repository",
+            "debug_mirrorlist",
+            "debug_metalink",
             # debug isos and jigdos are not supported
         ]
 

--- a/productmd/treeinfo.py
+++ b/productmd/treeinfo.py
@@ -411,16 +411,22 @@ class VariantPaths(productmd.common.MetadataBase):
 
         * **packages** -- directory with binary RPMs
         * **repository** -- YUM repository with binary RPMs
+        * **mirrolist** -- YUM mirrolist for binary RPMs
+        * **metalink** -- YUM metalink for binary RPMs
 
     **Source**
 
         * **source_packages** -- directory with source RPMs
         * **source_repository** -- YUM repository with source RPMs
+        * **source_mirrorlist** -- YUM mirrorlist for source RPMs
+        * **source_metalink** -- YUM metalink for source RPMs
 
     **Debug**
 
         * **debug_packages** -- directory with debug RPMs
         * **debug_repository** -- YUM repository with debug RPMs
+        * **debug_mirrorlist** -- YUM mirrorlist for debug RPMs
+        * **debug_metalink** -- YUM metalink for debug RPMs
 
     **Others**
         * **identity** -- path to a pem file which identifies a product
@@ -440,14 +446,20 @@ class VariantPaths(productmd.common.MetadataBase):
             # binary
             "packages",
             "repository",
+            "mirrorlist",
+            "metalink",
 
             # source
             "source_packages",
             "source_repository",
+            "source_mirrorlist",
+            "source_metalink",
 
             # debug
             "debug_packages",
             "debug_repository",
+            "debug_mirrorlist",
+            "debug_metalink",
 
             # others
             "identity",


### PR DESCRIPTION
For setting up CentOS Variants we will need the ability to set mirrorlists for repository URLs.  This PR explores what would be needed to get this first into .treeinfo support.

Remaining bits in this repo
- increment the .treeinfo version
- documentation
- unit tests

Didn't want to get too far before starting to chat on this....