### PR TITLE
Add missing parts to the TreeInfo documentation

### DIFF
--- a/doc/treeinfo.rst
+++ b/doc/treeinfo.rst
@@ -35,3 +35,19 @@ Classes
 
 .. autoclass:: productmd.treeinfo.Images
     :members:
+
+
+.. autoclass:: productmd.treeinfo.Stage2
+    :members:
+
+
+.. autoclass:: productmd.treeinfo.Media
+    :members:
+
+
+.. autoclass:: productmd.treeinfo.Tree
+    :members:
+
+
+.. autoclass:: productmd.treeinfo.Checksums
+    :members:


### PR DESCRIPTION
Stage2, Media, Tree and Checksums classes were missing in the documentation.