### PR TITLE
Add tests for multiple variants in one .treeinfo

### DIFF
--- a/tests/test_composeinfo.py
+++ b/tests/test_composeinfo.py
@@ -230,6 +230,38 @@ class TestComposeInfo(unittest.TestCase):
         self.assertEqual(ci.get_variants(), [variant])
         self.assertEqual(ci.get_variants(arch='x86_64'), [variant])
 
+    def test_multiple_variants(self):
+        ci = ComposeInfo()
+        ci.release.name = "Fedora"
+        ci.release.short = "F"
+        ci.release.version = "25"
+        ci.release.type = "ga"
+
+        ci.compose.id = "F-25-20150522.0"
+        ci.compose.type = "production"
+        ci.compose.date = "20161225"
+        ci.compose.respin = 0
+
+        varianta = Variant(ci)
+        varianta.id = "Server"
+        varianta.uid = "Server"
+        varianta.name = "Server"
+        varianta.type = "variant"
+        varianta.arches = set(["armhfp", "i386", "x86_64"])
+
+        variantb = Variant(ci)
+        variantb.id = "Client"
+        variantb.uid = "Client"
+        variantb.name = "Client"
+        variantb.type = "variant"
+        variantb.arches = set(["armhfp", "i386", "x86_64"])
+
+        ci.variants.add(varianta)
+        ci.variants.add(variantb)
+        ci.get_variants()
+        self.assertEqual(ci.get_variants(), [variantb, varianta])
+        self.assertEqual(ci.get_variants(arch='x86_64'), [variantb, varianta])
+
 
 class TestCreateComposeID(unittest.TestCase):
     def setUpRelease(self, compose_type, release_type, bp_type=None):

--- a/tests/test_treeinfo.py
+++ b/tests/test_treeinfo.py
@@ -221,12 +221,48 @@ class TestTreeInfo(unittest.TestCase):
             if i in ("fedora-8-Everything.x86_64", "fedora-8-Everything.ppc", "fedora-8-Everything.i386"):
                 # version == "development" -> can't read correctly
                 continue
+            if i in ("RHEL-8-BETA.aarch64", "RHEL-8-BETA.ppc64le", "RHEL-8-BETA.s390x", "RHEL-8-BETA.x86_64"):
+                # Not a Fedora file
+                continue
             path = os.path.join(self.treeinfo_path, i)
             ti = TreeInfo()
             ti.load(path)
             self.assertEqual(ti.release.short, "Fedora")
             self.assertEqual(ti.release.name, "Fedora")
             self.assertEqual(ti.release.version, str(int(ti.release.version)))
+
+    def test_read_RHEL_treeinfo(self):
+        for i in os.listdir(self.treeinfo_path):
+            if i not in ("RHEL-8-BETA.aarch64", "RHEL-8-BETA.ppc64le", "RHEL-8-BETA.s390x", "RHEL-8-BETA.x86_64"):
+                continue
+            path = os.path.join(self.treeinfo_path, i)
+            ti = TreeInfo()
+            ti.load(path)
+            self.assertEqual(ti.release.short, "RHEL")
+            self.assertEqual(ti.release.name, "Red Hat Enterprise Linux")
+            self.assertEqual(ti.release.version, str(ti.release.version))
+
+            # variants
+            self.assertEqual(len(ti.variants), 2)
+
+            # variant: BaseOS
+            var = ti.variants["BaseOS"]
+            self.assertEqual(var.id, "BaseOS")
+            self.assertEqual(var.uid, "BaseOS")
+            self.assertEqual(var.name, "BaseOS")
+            self.assertEqual(var.type, "variant")
+
+            self.assertEqual(var.paths.packages, "Packages")
+            self.assertEqual(var.paths.repository, ".")
+
+            # variant: AppStream
+            var = ti.variants["AppStream"]
+            self.assertEqual(var.id, "AppStream")
+            self.assertEqual(var.uid, "AppStream")
+            self.assertEqual(var.name, "AppStream")
+            self.assertEqual(var.type, "variant")
+
+            self.assertEqual(var.paths.packages, "Packages")
 
     def test_treeinfo_compute_checksum(self):
         tmp_file = os.path.join(self.tmp_dir, "file")

--- a/tests/treeinfo/RHEL-8-BETA.aarch64
+++ b/tests/treeinfo/RHEL-8-BETA.aarch64
@@ -1,0 +1,42 @@
+[general]
+arch = aarch64
+family = Red Hat Enterprise Linux
+name = Red Hat Enterprise Linux 8.0
+packagedir = ../../appstream/aarch64/Packages
+platforms = aarch64,xen
+repository = AppStream
+timestamp = 1542400051
+variant = AppStream
+variants = AppStream,BaseOS
+version = 8.0
+
+[header]
+type = productmd.treeinfo
+version = 1.2
+
+[release]
+name = Red Hat Enterprise Linux
+short = RHEL
+version = 8.0
+
+[tree]
+arch = aarch64
+build_timestamp = 1542400051
+platforms = aarch64,xen
+variants = AppStream,BaseOS
+
+[variant-AppStream]
+id = AppStream
+name = AppStream
+packages = Packages
+repository = ../../appstream/aarch64/
+type = variant
+uid = AppStream
+
+[variant-BaseOS]
+id = BaseOS
+name = BaseOS
+packages = Packages
+repository = .
+type = variant
+uid = BaseOS

--- a/tests/treeinfo/RHEL-8-BETA.ppc64le
+++ b/tests/treeinfo/RHEL-8-BETA.ppc64le
@@ -1,0 +1,42 @@
+[general]
+arch = ppc64le
+family = Red Hat Enterprise Linux
+name = Red Hat Enterprise Linux 8.0
+packagedir = ../../appstream/ppc64le/Packages
+platforms = ppc64le,xen
+repository = AppStream
+timestamp = 1542400051
+variant = AppStream
+variants = AppStream,BaseOS
+version = 8.0
+
+[header]
+type = productmd.treeinfo
+version = 1.2
+
+[release]
+name = Red Hat Enterprise Linux
+short = RHEL
+version = 8.0
+
+[tree]
+arch = ppc64le
+build_timestamp = 1542400051
+platforms = ppc64le,xen
+variants = AppStream,BaseOS
+
+[variant-AppStream]
+id = AppStream
+name = AppStream
+packages = Packages
+repository = ../../appstream/ppc64le/
+type = variant
+uid = AppStream
+
+[variant-BaseOS]
+id = BaseOS
+name = BaseOS
+packages = Packages
+repository = .
+type = variant
+uid = BaseOS

--- a/tests/treeinfo/RHEL-8-BETA.s390x
+++ b/tests/treeinfo/RHEL-8-BETA.s390x
@@ -1,0 +1,42 @@
+[general]
+arch = s390x
+family = Red Hat Enterprise Linux
+name = Red Hat Enterprise Linux 8.0
+packagedir = ../../appstream/s390x/Packages
+platforms = s390x,xen
+repository = AppStream
+timestamp = 1542400051
+variant = AppStream
+variants = AppStream,BaseOS
+version = 8.0
+
+[header]
+type = productmd.treeinfo
+version = 1.2
+
+[release]
+name = Red Hat Enterprise Linux
+short = RHEL
+version = 8.0
+
+[tree]
+arch = s390x
+build_timestamp = 1542400051
+platforms = s390x,xen
+variants = AppStream,BaseOS
+
+[variant-AppStream]
+id = AppStream
+name = AppStream
+packages = Packages
+repository = ../../appstream/s390x/
+type = variant
+uid = AppStream
+
+[variant-BaseOS]
+id = BaseOS
+name = BaseOS
+packages = Packages
+repository = .
+type = variant
+uid = BaseOS

--- a/tests/treeinfo/RHEL-8-BETA.x86_64
+++ b/tests/treeinfo/RHEL-8-BETA.x86_64
@@ -1,0 +1,42 @@
+[general]
+arch = x86_64
+family = Red Hat Enterprise Linux
+name = Red Hat Enterprise Linux 8.0
+packagedir = ../../appstream/x86_64/Packages
+platforms = x86_64,xen
+repository = AppStream
+timestamp = 1542400051
+variant = AppStream
+variants = AppStream,BaseOS
+version = 8.0
+
+[header]
+type = productmd.treeinfo
+version = 1.2
+
+[release]
+name = Red Hat Enterprise Linux
+short = RHEL
+version = 8.0
+
+[tree]
+arch = x86_64
+build_timestamp = 1542400051
+platforms = x86_64,xen
+variants = AppStream,BaseOS
+
+[variant-AppStream]
+id = AppStream
+name = AppStream
+packages = Packages
+repository = ../../appstream/x86_64/
+type = variant
+uid = AppStream
+
+[variant-BaseOS]
+id = BaseOS
+name = BaseOS
+packages = Packages
+repository = .
+type = variant
+uid = BaseOS


### PR DESCRIPTION
I'm having a hard time replicating the RHEL8 `.treeinfo` with pungi.  So while I was fighting with that, I generated some tests off of the RHEL8 beta treeinfo.

My actual problem is in pung, but hey... more unit tests are good :)