### PR TITLE
Set up test infrastructur

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,13 @@
 language: python
-python:
-    - "2.6"
-    - "2.7"
-    - "3.3"
-    - "3.4"
-    - "3.5"
-    - "3.6"
-script: "python setup.py test"
+matrix:
+    include:
+        - python: "2.7"
+          env: TOXENV=py27
+        - python: "3.6"
+          env: TOXENV=py36
+        - python: "3.7"
+          env: TOXENV=py37
+install:
+    - pip install tox
+script:
+    - tox -e $TOXENV

--- a/tox.ini
+++ b/tox.ini
@@ -5,3 +5,9 @@ max-line-length = 140
 
 [tox]
 skipsdist = True
+envlist = py27,py36,py37,py38
+skip_missing_interpreters = True
+
+[testenv]
+deps = pytest
+commands = pytest


### PR DESCRIPTION
- Use pytest with tox to run tests.
- Update travis to run tests via tox.
- Update list of supported Python versions. Technically 2.6 is still supported, but it does not work with tox, so we can't run the tests there.

Running tests with `setup.py test` still uses nose as runner.