### PR TITLE
Fix parsing composeinfo with almost conflicting UIDs

### DIFF
--- a/productmd/compose.py
+++ b/productmd/compose.py
@@ -143,6 +143,6 @@ class Compose(object):
         obj = cls()
         try:
             obj.load(path)
-        except ValueError:
-            raise RuntimeError('%s is not a valid JSON file.' % path)
+        except ValueError as exc:
+            raise RuntimeError('%s can not be deserialized: %s.' % (path, exc))
         return obj

--- a/tests/test_composeinfo.py
+++ b/tests/test_composeinfo.py
@@ -170,6 +170,42 @@ class TestComposeInfo(unittest.TestCase):
         self._test_identity(ci)
         return ci
 
+    def test_create_with_prefixed_uid(self):
+        ci = ComposeInfo()
+        ci.release.name = "Fedora"
+        ci.release.short = "F"
+        ci.release.version = "22"
+        ci.release.type = "ga"
+
+        ci.compose.id = "F-22-20150522.0"
+        ci.compose.type = "production"
+        ci.compose.date = "20150522"
+        ci.compose.respin = 0
+
+        # 2 Tools variants: one for Server, one for Workstation
+        # but parent variants are not part of the compose
+        variant = Variant(ci)
+        variant.id = "Foo"
+        variant.uid = "Foo"
+        variant.name = "Foo"
+        variant.type = "variant"
+        variant.arches = set(["x86_64"])
+        ci.variants.add(variant)
+        ci.variants["Foo"]
+
+        variant = Variant(ci)
+        variant.id = "FooBar"
+        variant.uid = "Foo-Bar"
+        variant.name = "Foo-Bar"
+        variant.type = "variant"
+        variant.arches = set(["x86_64"])
+        ci.variants.add(variant)
+        ci.variants["Foo-Bar"]
+
+        ci.dump(self.ci_path)
+        self._test_identity(ci)
+        return ci
+
     def test_get_variants(self):
         ci = ComposeInfo()
         ci.release.name = "Fedora"


### PR DESCRIPTION
When the metadata contains variants `Foo` and `Foo-Bar`, the deserialization logic always applies a workaround for old metadata that did not explicitly contain parent-child relationship. Thus `Foo-Bar` ends up as a child of `Foo`, even though they may be unrelated.

The fix is to only apply the workaround when metadata version is too old.

This PR also fixes a long standing issue with error reporting. Instead of reporting an incorrect exception about file not being a valid JSON, print the actual reason (which could be a validation problem).