### PR TITLE
Fix dumping extra_files metadata when CWD is deleted

### DIFF
--- a/productmd/extra_files.py
+++ b/productmd/extra_files.py
@@ -16,7 +16,6 @@
 # along with this program; if not, see <https://gnu.org/licenses/>.
 
 import json
-import os
 
 import productmd.common
 from productmd.common import Header, RPM_ARCHES
@@ -82,10 +81,17 @@ class ExtraFiles(productmd.common.MetadataBase):
         for item in self.extra_files[variant][arch]:
             metadata["data"].append(
                 {
-                    "file": os.path.relpath(item["file"], basepath),
+                    "file": _relative_to(item["file"], basepath),
                     "size": item["size"],
                     "checksums": item["checksums"],
                 }
             )
 
         json.dump(metadata, output, sort_keys=True, indent=4, separators=(",", ": "))
+
+
+def _relative_to(path, root):
+    root = root.rstrip("/") + "/"
+    if path.startswith(root):
+        return path[len(root):]
+    return path

--- a/tests/test_extra_files.py
+++ b/tests/test_extra_files.py
@@ -38,7 +38,7 @@ class TestExtraFiles(unittest.TestCase):
         self.tmp_dir = tempfile.mkdtemp()
 
     def tearDown(self):
-        shutil.rmtree(self.tmp_dir)
+        shutil.rmtree(self.tmp_dir, ignore_errors=True)
 
     def assertSameFiles(self, path1, path2):
         self.assertEqual(os.path.getsize(path1), os.path.getsize(path2))
@@ -158,3 +158,25 @@ class TestExtraFiles(unittest.TestCase):
                 ],
             },
         )
+
+    def test_partial_dump_in_deleted_directory(self):
+        os.chdir(self.tmp_dir)
+        shutil.rmtree(self.tmp_dir)
+
+        metadata = ExtraFiles()
+        metadata.header.version = "1.0"
+        metadata.compose.id = "Fedora-20-20131212.0"
+        metadata.compose.type = "production"
+        metadata.compose.date = "20131212"
+        metadata.compose.respin = 0
+
+        metadata.add(
+            "Everything",
+            "x86_64",
+            "compose/Everything/x86_64/os/GPL",
+            size=123,
+            checksums={"md5": "abcde", "sha512": "a1b2c3"},
+        )
+
+        out = StringIO()
+        metadata.dump_for_tree(out, "Everything", "x86_64", "compose/Everything/x86_64/os")


### PR DESCRIPTION
The os.path.relpath function always tries to find out current working directory. It crashes if $CWD is deleted.