### PR TITLE
Fix validation for top-level Variant UIDs with dashes

### DIFF
--- a/productmd/composeinfo.py
+++ b/productmd/composeinfo.py
@@ -577,6 +577,8 @@ class VariantBase(productmd.common.MetadataBase):
     def _validate_variants(self):
         for variant_id in self:
             variant = self[variant_id]
+            if variant.parent is None and '-' in variant_id:
+                variant_id = variant_id.replace("-", "")
             if variant.id != variant_id:
                 raise ValueError("Variant ID doesn't match: '%s' vs '%s'" % (variant.id, variant_id))
 


### PR DESCRIPTION
Dash (-) is removed from variant.id in this case.

See https://pagure.io/pungi/c/f0aecf6744816751d9511c4f6e9347c6c7eaeb26?branch=master
https://github.com/release-engineering/productmd/commit/959e5345693f7b02c242f957764562dfed2350be

JIRA: RHELCMP-127