### PR TITLE
Fix validation for optional variant

### DIFF
--- a/productmd/composeinfo.py
+++ b/productmd/composeinfo.py
@@ -577,10 +577,15 @@ class VariantBase(productmd.common.MetadataBase):
     def _validate_variants(self):
         for variant_id in self:
             variant = self[variant_id]
-            if variant.parent is None and '-' in variant_id:
+            if variant.parent is None and '-' in variant_id and variant.type != "optional":
                 variant_id = variant_id.replace("-", "")
-            if variant.id != variant_id:
-                raise ValueError("Variant ID doesn't match: '%s' vs '%s'" % (variant.id, variant_id))
+
+            if variant.type == "optional":
+                if variant.uid != variant_id:
+                    raise ValueError("Variant UID doesn't match: '%s' vs '%s'" % (variant.uid, variant_id))
+            else:
+                if variant.id != variant_id:
+                    raise ValueError("Variant ID doesn't match: '%s' vs '%s'" % (variant.id, variant_id))
 
     def add(self, variant, variant_id=None):
         if hasattr(self, "uid"):

--- a/tests/test_treeinfo.py
+++ b/tests/test_treeinfo.py
@@ -235,6 +235,8 @@ class TestTreeInfo(unittest.TestCase):
         for i in os.listdir(self.treeinfo_path):
             if "RHEL" not in i:
                 continue
+            if "optional" in i:
+                continue
             path = os.path.join(self.treeinfo_path, i)
             ti = TreeInfo()
             ti.load(path)
@@ -263,6 +265,19 @@ class TestTreeInfo(unittest.TestCase):
             self.assertEqual(var.type, "variant")
 
             self.assertEqual(var.paths.packages, "Packages")
+
+    def test_read_RHEL_Server_optional_treeinfo(self):
+        path = os.path.join(self.treeinfo_path, "RHEL-7-Server-optional.x86_64")
+        ti = TreeInfo()
+        ti.load(path)
+
+        var = ti.variants["Server-optional"]
+        self.assertEqual(var.id, "optional")
+        self.assertEqual(var.uid, "Server-optional")
+        self.assertEqual(var.name, "optional")
+        self.assertEqual(var.type, "optional")
+        self.assertEqual(var.paths.packages, "Packages")
+        self.assertEqual(var.paths.repository, ".")
 
     def test_treeinfo_compute_checksum(self):
         tmp_file = os.path.join(self.tmp_dir, "file")

--- a/tests/treeinfo/RHEL-7-Server-optional.x86_64
+++ b/tests/treeinfo/RHEL-7-Server-optional.x86_64
@@ -1,0 +1,34 @@
+[general]
+arch = x86_64
+family = Red Hat Enterprise Linux
+name = Red Hat Enterprise Linux 7.0
+packagedir = Packages
+platforms = x86_64
+repository = .
+timestamp = 1592881577
+variant = optional
+variants = optional
+version = 7.0
+
+[header]
+type = productmd.treeinfo
+version = 1.2
+
+[release]
+name = Red Hat Enterprise Linux
+short = RHEL
+version = 7.0
+
+[tree]
+arch = x86_64
+build_timestamp = 1592881577
+platforms = x86_64
+variants = Server-optional
+
+[variant-Server-optional]
+id = optional
+name = optional
+packages = Packages
+repository = .
+type = optional
+uid = Server-optional


### PR DESCRIPTION
treeinfo.Variants._validate_variants() was removed in previous commit(2518da2)
and after that composeinfo.VariantBase._validate_variants() is called for
Variants validaton.

When variant.type == "optional", variant.uid should be used for validaton.

JIRA: RHELCMP-1184
Signed-off-by: Haibo Lin <hlin@redhat.com>