### PR TITLE
Use tar.gz for source distribution

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,0 @@
-[sdist]
-formats = bztar


### PR DESCRIPTION
PyPI no longer accepts tar.bz2: https://www.python.org/dev/peps/pep-0527/