### PR TITLE
fix release short name validated failed

### DIFF
--- a/productmd/treeinfo.py
+++ b/productmd/treeinfo.py
@@ -246,7 +246,7 @@ class Release(BaseProduct):
             self.name = "CentOS"
             self.short = "CentOS"
         else:
-            self.short = None
+            self.short = ""
 
     def deserialize_0_3(self, parser):
         self.name = parser.get("product", "name")


### PR DESCRIPTION
Hello:
I was making Linux distributions based on Fedora(lorax for build, anaconda for installer). But it is failed during anaconda install.
After simply debuging for that, I found it is failed in parsering _.treeinfo_ which is a hidden file in ISO.
Because, release-short-name in my treeinfo is not startwith Fedora, CentOS or RHEL. 
So, Type-Check failed...
`
def _validate_short(self):
        self._assert_type("short", list(six.string_types))
`
If deserialize_0_0 return **""** other then **None**, It would be better ;)
