### PR TITLE
Add ability to productmd set a main variant while dumping TreeInfo:

### DIFF
--- a/productmd/common.py
+++ b/productmd/common.py
@@ -169,7 +169,7 @@ def _urlopen(path):
 
 
 @contextlib.contextmanager
-def _open_file_obj(f, mode="r"):
+def open_file_obj(f, mode="r"):
     """
     A context manager that provides access to a file.
 
@@ -258,7 +258,7 @@ class MetadataBase(object):
         :param f: file-like object or path to file
         :type f: file or str
         """
-        with _open_file_obj(f) as f:
+        with open_file_obj(f) as f:
             parser = self.parse_file(f)
             self.deserialize(parser)
 
@@ -283,7 +283,7 @@ class MetadataBase(object):
         :type f: file or str
         """
         self.validate()
-        with _open_file_obj(f, "w") as f:
+        with open_file_obj(f, "w") as f:
             parser = self._get_parser()
             self.serialize(parser)
             self.build_file(parser, f)

--- a/tests/test_treeinfo.py
+++ b/tests/test_treeinfo.py
@@ -94,6 +94,60 @@ class TestTreeInfo(unittest.TestCase):
         ti.dump(self.ini_path)
         self._test_identity(ti)
 
+    def test_create_with_two_variants(self):
+        ti = TreeInfo()
+        ti.release.name = "Fedora"
+        ti.release.short = "F"
+        ti.release.version = "20"
+
+        ti.tree.arch = "x86_64"
+        ti.tree.build_timestamp = 123456
+
+        variant_1 = Variant(ti)
+        variant_1.id = "AppStream"
+        variant_1.uid = "AppStream"
+        variant_1.name = "AppStream"
+        variant_1.type = "variant"
+
+        variant_1.paths.repository = "repo"
+        variant_1.paths.packages = "pkgs"
+        variant_1.paths.source_repository = "src repo"
+        variant_1.paths.source_packages = "src pkgs"
+        variant_1.paths.debug_repository = "debug repo"
+        variant_1.paths.debug_packages = "debug pkgs"
+        variant_1.paths.identity = "cert.pem"
+
+        ti.variants.add(variant_1)
+
+        variant_2 = Variant(ti)
+        variant_2.id = "BaseOS"
+        variant_2.uid = "BaseOS"
+        variant_2.name = "BaseOS"
+        variant_2.type = "variant"
+
+        variant_2.paths.repository = "repo_2"
+        variant_2.paths.packages = "pkgs_2"
+        variant_2.paths.source_repository = "src repo 2"
+        variant_2.paths.source_packages = "src pkgs 2"
+        variant_2.paths.debug_repository = "debug repo 2"
+        variant_2.paths.debug_packages = "debug pkgs 2"
+        variant_2.paths.identity = "cert2.pem"
+
+        ti.variants.add(variant_2)
+
+        ti.dump(self.ini_path, main_variant='BaseOS')
+        with open(
+                self.ini_path, 'r'
+        ) as treeinfo_1, open(
+            os.path.join(DIR, "treeinfo/multivariants_treeinfo")
+        ) as treeinfo_2:
+            treeinfo_1_lines = treeinfo_1.readlines()
+            treeinfo_2_lines = treeinfo_2.readlines()
+        self.assertEqual(
+            treeinfo_1_lines,
+            treeinfo_2_lines,
+        )
+
     def test_f20(self):
         ti = TreeInfo()
         ti.load(os.path.join(DIR, "treeinfo/fedora-20-Fedora.x86_64"))

--- a/tests/treeinfo/multivariants_treeinfo
+++ b/tests/treeinfo/multivariants_treeinfo
@@ -1,0 +1,55 @@
+[general]
+; WARNING.0 = This section provides compatibility with pre-productmd treeinfos.
+; WARNING.1 = Read productmd documentation for details about new format.
+arch = x86_64
+family = Fedora
+name = Fedora 20
+packagedir = pkgs_2
+platforms = x86_64
+repository = repo_2
+timestamp = 123456
+variant = BaseOS
+variants = AppStream,BaseOS
+version = 20
+
+[header]
+type = productmd.treeinfo
+version = 1.2
+
+[release]
+name = Fedora
+short = F
+version = 20
+
+[tree]
+arch = x86_64
+build_timestamp = 123456
+platforms = x86_64
+variants = AppStream,BaseOS
+
+[variant-AppStream]
+debug_packages = debug pkgs
+debug_repository = debug repo
+id = AppStream
+identity = cert.pem
+name = AppStream
+packages = pkgs
+repository = repo
+source_packages = src pkgs
+source_repository = src repo
+type = variant
+uid = AppStream
+
+[variant-BaseOS]
+debug_packages = debug pkgs 2
+debug_repository = debug repo 2
+id = BaseOS
+identity = cert2.pem
+name = BaseOS
+packages = pkgs_2
+repository = repo_2
+source_packages = src pkgs 2
+source_repository = src repo 2
+type = variant
+uid = BaseOS
+


### PR DESCRIPTION
- It's added ability to set a main variant for multi-variants TreeInfo while dumping it
- The ability is covered by the unittests