### PR TITLE
Fix support for ftp protocol when fetching metadata

### DIFF
--- a/productmd/common.py
+++ b/productmd/common.py
@@ -195,7 +195,7 @@ def _file_exists(path):
         try:
             file_obj = _urlopen(path)
             file_obj.close()
-        except six.moves.urllib.error.HTTPError:
+        except six.moves.urllib.error.URLError:
             return False
         return True
     return os.path.exists(path)


### PR DESCRIPTION
When using FTP urlopen raises URLError, not HTTPError. URLError works with all protocols.