### PR TITLE
Compose: test existence of compose/metadata/composeinfo.json

### DIFF
--- a/productmd/compose.py
+++ b/productmd/compose.py
@@ -63,7 +63,7 @@ class Compose(object):
 
         # example: MYPRODUCT-1.0-YYYYMMDD.0/compose/metadata (preferred location)
         path = os.path.join(compose_path, "compose")
-        if _file_exists(path):
+        if _file_exists(os.path.join(path, "metadata/composeinfo.json")):
             self.compose_path = path
 
         elif "://" not in compose_path and os.path.exists(compose_path):


### PR DESCRIPTION
s3 returns 404 errors for parent directories, because all object names are simply keys with `/` characters, and "directories" do not exist.

Rather than testing the existence of the `compose` directory, test for a well-known file that is present in all modern composes: `compose/metadata/composeinfo.json`

Fixes: #168 