### PR TITLE
images: add `live-osbuild` image type

### DIFF
--- a/productmd/images.py
+++ b/productmd/images.py
@@ -81,6 +81,7 @@ IMAGE_TYPE_FORMAT_MAPPING = {
     'ec2': [],
     'kvm': [],
     'live': [],
+    'live-osbuild': ['iso'],
     'liveimg-squashfs': ['liveimg.squashfs'],
     'netinst': ['iso'],
     'p2v': [],

--- a/productmd/images.py
+++ b/productmd/images.py
@@ -78,6 +78,7 @@ IMAGE_TYPE_FORMAT_MAPPING = {
     # installer image that deploys a payload containing an ostree-based
     # distribution
     'dvd-ostree': ['iso'],
+    'dvd-ostree-osbuild': ['iso'],
     'ec2': [],
     'kvm': [],
     'live': [],


### PR DESCRIPTION
Adding a new image type to prepare `productmd` for recognizing [osbuild](https://github.com/osbuild)-built images. See discussion here: https://pagure.io/pungi-fedora/pull-request/1190#comment-190470

I'm still not entirely clear if this is the right approach so a better approach if it exists, let me know!