### PR TITLE
Add mappings for appx and iso types for kiwi image builds

### DIFF
--- a/productmd/images.py
+++ b/productmd/images.py
@@ -69,6 +69,7 @@ __all__ = (
 )
 
 IMAGE_TYPE_FORMAT_MAPPING = {
+    'appx': ['appx'],
     'boot': ['iso'],
     'cd': ['iso'],
     'docker': ['tar.gz', 'tar.xz'],
@@ -80,6 +81,7 @@ IMAGE_TYPE_FORMAT_MAPPING = {
     'dvd-ostree': ['iso'],
     'dvd-ostree-osbuild': ['iso'],
     'ec2': [],
+    'iso': ['iso'],
     'kvm': [],
     'live': [],
     'live-osbuild': ['iso'],


### PR DESCRIPTION
This ensures that pungi (which connects kiwi image types to productmd image types/formats), will not reject builds of these extra types.