### PR TITLE
Remove 'iso' image type again

### DIFF
--- a/productmd/images.py
+++ b/productmd/images.py
@@ -81,7 +81,6 @@ IMAGE_TYPE_FORMAT_MAPPING = {
     'dvd-ostree': ['iso'],
     'dvd-ostree-osbuild': ['iso'],
     'ec2': [],
-    'iso': ['iso'],
     'kvm': [],
     'live': [],
     'live-osbuild': ['iso'],


### PR DESCRIPTION
I believe adding this was incorrect. 'iso' makes no sense as an "image type" in productmd terms. See
https://pagure.io/pungi-fedora/issue/1342#comment-927846 and https://pagure.io/pungi-fedora/issue/1342#comment-927848 for a more detailed rationale. We need to fix the Kiwi/Pungi pipeline such that ISO images it produces have correct "type"s, not add conceptually-nonsensical types to productmd so the current pipeline works.