### PR TITLE
common: Update RPM_ARCHES to match dnf

### DIFF
--- a/productmd/common.py
+++ b/productmd/common.py
@@ -63,14 +63,18 @@ __all__ = (
 )
 
 
-# HACK: dumped from rpmUtils.arch which is not available on python3
-# one less dependency at least :)
+# HACK: synced from _BASEARCH_MAP as defined in
+# https://github.com/rpm-software-management/dnf/blob/master/dnf/rpm/__init__.py
+#
+# additional values that are not present in that dictionary but are retained
+# here to ensure backwards compatibility: arm64, src, nosrc
 RPM_ARCHES = [
     "aarch64", "alpha", "alphaev4", "alphaev45", "alphaev5", "alphaev56", "alphaev6", "alphaev67", "alphaev68",
-    "alphaev7", "alphapca56", "amd64", "arm64", "armhfp", "armv5tejl", "armv5tel", "armv6hl", "armv6l", "armv7hl",
-    "armv7hnl", "armv7l", "athlon", "geode", "i386", "i486", "i586", "i686", "ia32e", "ia64", "ppc", "ppc64",
-    "ppc64iseries", "ppc64le", "ppc64p7", "ppc64pseries", "s390", "s390x", "sh3", "sh4", "sh4a",
-    "sparc", "sparc64", "sparc64v", "sparcv8", "sparcv9", "sparcv9v", "x86_64",
+    "alphaev7", "alphapca56", "amd64", "arm64", "armhfp", "armv5tejl", "armv5tel", "armv5tl", "armv6hl",
+    "armv6l", "armv7hl", "armv7hnl", "armv7l", "armv8hl", "armv8l", "athlon", "geode", "i386", "i486", "i586",
+    "i686", "ia32e", "ia64", "loongarch64", "mips", "mips64", "mips64el", "mipsel", "ppc", "ppc64",
+    "ppc64iseries", "ppc64le", "ppc64p7", "ppc64pseries", "riscv128", "riscv32", "riscv64", "s390", "s390x",
+    "sh3", "sh4", "sh4a", "sparc", "sparc64", "sparc64v", "sparcv8", "sparcv9", "sparcv9v", "x86_64",
     "src", "nosrc", "noarch",
 ]
 


### PR DESCRIPTION
Since the list was last updated in 2015, rpm has learned about a few additional architectures.

Specifically, the following architectures are added:

```
armv5tl, armv8hl, armv8l,
loongarch64,
mips, mips64, mips64el, mipsel,
riscv128, riscv32, riscv64,
```

Of those, riscv64 and loongarch64 are particularly relevant to upcoming and in progress Fedora ports.