### PR TITLE
images: add type and formats for erofs and squashfs to back FEX

### DIFF
--- a/productmd/images.py
+++ b/productmd/images.py
@@ -107,6 +107,9 @@ IMAGE_TYPE_FORMAT_MAPPING = {
     'vpc': ['vhd'],
     'vhd-compressed': ['vhd.gz', 'vhd.xz'],
     'vsphere-ova': ['vsphere.ova'],
+    # these back FEX:
+    # https://fedoraproject.org/wiki/Changes/FEX
+    'fex': ['erofs.xz', 'erofs.gz', 'erofs', 'squashfs.xz', 'squashfs.gz', 'squashfs'],
 }
 
 #: supported image types


### PR DESCRIPTION
See https://fedoraproject.org/wiki/Changes/FEX ,
https://pagure.io/koji/pull-request/4219 ,
https://pagure.io/fedora-kiwi-descriptions/c/03aacd1 etc. We seem to be growing these images in Fedora composes, so we need a type and formats for them in productmd. These seem to be the logical choices - all these image formats seem to be intended for use with FEX, so I'm putting them all under the type 'fex'.