### PR TITLE
images: add bootc type, move fex to preserve alphabetical order

### DIFF
--- a/productmd/images.py
+++ b/productmd/images.py
@@ -71,7 +71,11 @@ __all__ = (
 IMAGE_TYPE_FORMAT_MAPPING = {
     'appx': ['appx'],
     'boot': ['iso'],
+    # for all bootable container images, see https://github.com/containers/bootc
+    # and https://coreos.github.io/rpm-ostree/container/
+    'bootable-container': ['ociarchive'],
     'cd': ['iso'],
+    'container': ['tar.xz', 'oci', 'ociarchive'],
     'docker': ['tar.gz', 'tar.xz'],
     'dvd': ['iso'],
     # Usually non-bootable image which contains a repo with debuginfo packages.
@@ -81,6 +85,9 @@ IMAGE_TYPE_FORMAT_MAPPING = {
     'dvd-ostree': ['iso'],
     'dvd-ostree-osbuild': ['iso'],
     'ec2': [],
+    # these back FEX:
+    # https://fedoraproject.org/wiki/Changes/FEX
+    'fex': ['erofs.xz', 'erofs.gz', 'erofs', 'squashfs.xz', 'squashfs.gz', 'squashfs'],
     'kvm': [],
     'live': [],
     'live-osbuild': ['iso'],
@@ -107,9 +114,6 @@ IMAGE_TYPE_FORMAT_MAPPING = {
     'vpc': ['vhd'],
     'vhd-compressed': ['vhd.gz', 'vhd.xz'],
     'vsphere-ova': ['vsphere.ova'],
-    # these back FEX:
-    # https://fedoraproject.org/wiki/Changes/FEX
-    'fex': ['erofs.xz', 'erofs.gz', 'erofs', 'squashfs.xz', 'squashfs.gz', 'squashfs'],
 }
 
 #: supported image types


### PR DESCRIPTION
This adds a 'bootc' type. See:
https://pagure.io/fedora-iot/pungi-iot/pull-request/102#comment-210617 for some discussion here. Right now, when we build a bootc image, its type and format are both 'ociarchive'. I don't like this; it's redundant, and 'ociarchive' isn't really a helpful image 'type' anyway. It really just means "this is some kind of container image", and container images can be for hugely different purposes. I think bootc images having format 'ociarchive' and type 'bootc' is much more meaningful and useful.