### PR TITLE
Add 'wsl' format for wsl2 images

### DIFF
--- a/productmd/images.py
+++ b/productmd/images.py
@@ -110,7 +110,7 @@ IMAGE_TYPE_FORMAT_MAPPING = {
     'vhd-compressed': ['vhd.gz', 'vhd.xz'],
     'vsphere-ova': ['vsphere.ova'],
     # https://learn.microsoft.com/en-us/windows/wsl/use-custom-distro
-    'wsl2': ['tar', 'tar.gz'],
+    'wsl2': ['tar', 'tar.gz', 'wsl'],
 }
 
 #: supported image types


### PR DESCRIPTION
WSL images can now literally have the format .wsl, according to Neal and Yaakov. This is fine. So let's allow it.

See: https://pagure.io/pungi/pull-request/1841