### PR TITLE
Allow .vhdfixed.xz format for vhd-compressed type

### DIFF
--- a/productmd/images.py
+++ b/productmd/images.py
@@ -107,7 +107,7 @@ IMAGE_TYPE_FORMAT_MAPPING = {
     'vdi': ['vdi'],
     'vmdk': ['vmdk'],
     'vpc': ['vhd'],
-    'vhd-compressed': ['vhd.gz', 'vhd.xz'],
+    'vhd-compressed': ['vhd.gz', 'vhd.xz', 'vhdfixed.xz'],
     'vsphere-ova': ['vsphere.ova'],
     # https://learn.microsoft.com/en-us/windows/wsl/use-custom-distro
     'wsl2': ['tar', 'tar.gz', 'wsl'],


### PR DESCRIPTION
Current Fedora Azure images are named e.g.:
Fedora-Cloud-Base-Azure-Rawhide-20260106.n.0.aarch64.vhdfixed.xz and have type vhd-compressed. We should 'allow' this in the supported type/format definitions.