### PR TITLE
Automate PyPi package publishing

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,0 +1,61 @@
+name: CD
+
+on:
+  workflow_run:
+    workflows: ["CI"]
+    types:
+      - completed
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    if: >
+      github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.event == 'release'
+
+    container:
+      image: registry.access.redhat.com/ubi10/ubi:latest
+
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.workflow_run.head_sha }}
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          version-file: ".python-version"
+          version: "0.9.26"
+
+      - name: Build package
+        run: uv build
+
+      - name: Upload dist artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+  publish-pypi:
+    runs-on: ubuntu-latest
+    needs: build
+
+    environment:
+      name: pypi
+      url: https://pypi.org/project/productmd/
+
+    permissions:
+      id-token: write # Required for trusted publishing
+
+    steps:
+      - name: Download dist artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        # with:
+        #   repository-url: https://test.pypi.org/legacy/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,8 @@ on:
       - "pyproject.toml"
       - "Containerfile.py36"
       - ".github/workflows/ci.yml"
+  release:
+    types: [published]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/README.md
+++ b/README.md
@@ -71,20 +71,33 @@ This will generate the **source** and **wheel** packages under the `dist` direct
 
 ### Releasing
 
-To release a new version:
+To release a new version and publish to PyPI:
 
-```bash
-# Bump version in pyproject.toml
-uv version <new_version>
+1. **Bump the version** in `pyproject.toml`:
 
-# Commit, tag, and push
-git add pyproject.toml
-git commit -m "Bump version to <new_version>"
-git tag <new_version>
-git push origin master --tags
-```
+   ```bash
+   uv version <new_version>
+   ```
 
-See [uv version docs](https://docs.astral.sh/uv/reference/cli/#uv-version) for other version commands (e.g., `uv version --bump minor`).
+   See [uv version docs](https://docs.astral.sh/uv/reference/cli/#uv-version) for other version commands (e.g., `uv version --bump minor`).
+
+2. **Commit and push** the version change:
+
+   ```bash
+   git add pyproject.toml uv.lock
+   git commit -m "Bump version to <new_version>"
+   git push origin master
+   ```
+
+3. **Create a GitHub release**:
+   - Go to [Releases](../../releases) and click **"Create a new release"**
+   - Pin the release to a tag following the format `vX.X` (e.g., `v1.0`, `v2.1`)
+   - Fill in the release title and notes
+   - Click **"Publish release"**
+
+4. **Automated publishing**:
+   - Publishing the release triggers the CI pipeline
+   - If CI passes, the CD pipeline automatically builds and publishes the package to PyPI
 
 ## License
 


### PR DESCRIPTION
Add workflow for building and publishing package into PyPi.

> **Some configuration required at the repo level and PyPi**
> See: https://docs.astral.sh/uv/guides/integration/github/#publishing-to-pypi

Part of: https://github.com/release-engineering/productmd/pull/194