### PR TITLE
Version detection and handling utilities

### DIFF
--- a/productmd/__init__.py
+++ b/productmd/__init__.py
@@ -39,3 +39,13 @@ from .images import Images  # noqa
 from .modules import Modules  # noqa
 from .rpms import Rpms  # noqa
 from .treeinfo import TreeInfo  # noqa
+from .version import (  # noqa
+    VERSION_1_0,
+    VERSION_1_1,
+    VERSION_1_2,
+    VERSION_2_0,
+    DEFAULT_VERSION,
+    detect_version_from_data,
+    is_v1,
+    is_v2,
+)

--- a/productmd/version.py
+++ b/productmd/version.py
@@ -1,0 +1,268 @@
+# Copyright (C) 2024  Red Hat, Inc.
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+
+"""
+This module provides version detection and handling utilities for ProductMD metadata.
+
+ProductMD supports multiple metadata format versions:
+
+- **v1.x** (1.0, 1.1, 1.2): Local compose format with relative paths
+- **v2.0**: Distributed compose format with Location objects
+
+This module provides utilities to:
+- Detect the version of parsed metadata
+- Check version compatibility
+- Convert between version representations
+
+Example::
+
+    from productmd.version import (
+        detect_version_from_data,
+        is_v1,
+        is_v2,
+        VERSION_1_2,
+        VERSION_2_0,
+        DEFAULT_VERSION,
+    )
+
+    # Detect version from parsed JSON data
+    data = {"header": {"version": "2.0", "type": "productmd.images"}, "payload": {}}
+    version = detect_version_from_data(data)
+    print(version)  # (2, 0)
+
+    # Check version type
+    if is_v2(version):
+        print("This is a v2.0 distributed compose")
+    elif is_v1(version):
+        print("This is a v1.x local compose")
+
+    # Version constants
+    print(VERSION_2_0)  # (2, 0)
+    print(DEFAULT_VERSION)  # (2, 0) - default for new files
+"""
+
+from typing import Tuple, Union, Optional, Any, Dict
+
+__all__ = (
+    "VERSION_1_0",
+    "VERSION_1_1",
+    "VERSION_1_2",
+    "VERSION_2_0",
+    "DEFAULT_VERSION",
+    "detect_version_from_data",
+    "is_v1",
+    "is_v2",
+    "get_version_tuple",
+    "version_to_string",
+    "string_to_version",
+    "VersionError",
+    "UnsupportedVersionError",
+)
+
+
+# Version constants
+VERSION_1_0: Tuple[int, int] = (1, 0)
+VERSION_1_1: Tuple[int, int] = (1, 1)
+VERSION_1_2: Tuple[int, int] = (1, 2)
+VERSION_2_0: Tuple[int, int] = (2, 0)
+
+# Current default version for writing new files
+DEFAULT_VERSION: Tuple[int, int] = VERSION_2_0
+
+# Minimum version that supports Location objects
+MIN_LOCATION_VERSION: Tuple[int, int] = VERSION_2_0
+
+
+class VersionError(Exception):
+    """Base exception for version-related errors."""
+
+    pass
+
+
+class UnsupportedVersionError(VersionError):
+    """Raised when a metadata file has an unsupported version."""
+
+    def __init__(self, version: Tuple[int, int], supported: list = None):
+        self.version = version
+        self.supported = supported or [VERSION_1_0, VERSION_1_1, VERSION_1_2, VERSION_2_0]
+        super().__init__(
+            f"Unsupported metadata version: {version_to_string(version)}. "
+            f"Supported versions: {', '.join(version_to_string(v) for v in self.supported)}"
+        )
+
+
+def version_to_string(version: Tuple[int, int]) -> str:
+    """
+    Convert a version tuple to a string.
+
+    :param version: Version tuple (major, minor)
+    :type version: tuple
+    :return: Version string like "2.0"
+    :rtype: str
+    """
+    return f"{version[0]}.{version[1]}"
+
+
+def string_to_version(version_str: str) -> Tuple[int, int]:
+    """
+    Convert a version string to a tuple.
+
+    :param version_str: Version string like "2.0"
+    :type version_str: str
+    :return: Version tuple (major, minor)
+    :rtype: tuple
+    :raises ValueError: If version string is invalid
+    """
+    try:
+        parts = version_str.split(".")
+        return (int(parts[0]), int(parts[1]))
+    except (ValueError, IndexError) as e:
+        raise ValueError(f"Invalid version string: {version_str}") from e
+
+
+def get_version_tuple(version: Union[str, Tuple[int, int]]) -> Tuple[int, int]:
+    """
+    Normalize version to a tuple.
+
+    :param version: Version as string or tuple
+    :type version: str or tuple
+    :return: Version tuple (major, minor)
+    :rtype: tuple
+    """
+    if isinstance(version, str):
+        return string_to_version(version)
+    return version
+
+
+def is_v1(version: Union[str, Tuple[int, int]]) -> bool:
+    """
+    Check if version is v1.x (1.0, 1.1, 1.2).
+
+    :param version: Version to check
+    :type version: str or tuple
+    :return: True if v1.x
+    :rtype: bool
+    """
+    v = get_version_tuple(version)
+    return v[0] == 1
+
+
+def is_v2(version: Union[str, Tuple[int, int]]) -> bool:
+    """
+    Check if version is v2.x (2.0+).
+
+    :param version: Version to check
+    :type version: str or tuple
+    :return: True if v2.x
+    :rtype: bool
+    """
+    v = get_version_tuple(version)
+    return v[0] == 2
+
+
+def supports_location_objects(version: Union[str, Tuple[int, int]]) -> bool:
+    """
+    Check if version supports Location objects.
+
+    :param version: Version to check
+    :type version: str or tuple
+    :return: True if Location objects are supported
+    :rtype: bool
+    """
+    v = get_version_tuple(version)
+    return v >= MIN_LOCATION_VERSION
+
+
+def detect_version_from_data(data: Dict[str, Any]) -> Tuple[int, int]:
+    """
+    Detect the version from parsed metadata.
+
+    :param data: Parsed JSON data
+    :type data: dict
+    :return: Version tuple (major, minor)
+    :rtype: tuple
+    :raises ValueError: If version cannot be determined
+    """
+    # Check for header.version (standard location)
+    if "header" in data and "version" in data["header"]:
+        return string_to_version(data["header"]["version"])
+
+    raise ValueError("Cannot determine metadata version from data")
+
+
+class VersionedMetadataMixin:
+    """
+    Mixin class providing version-aware serialization/deserialization.
+
+    This mixin can be added to metadata classes to provide automatic
+    version detection and handling.
+
+    Usage::
+
+        class MyMetadata(MetadataBase, VersionedMetadataMixin):
+            def deserialize(self, data):
+                version = self.detect_data_version(data)
+                if is_v2(version):
+                    self.deserialize_2_0(data)
+                else:
+                    self.deserialize_1_x(data)
+    """
+
+    # Default output version (can be overridden per-class or per-instance)
+    _output_version: Optional[Tuple[int, int]] = None
+
+    @property
+    def output_version(self) -> Tuple[int, int]:
+        """
+        Get the version to use when serializing.
+
+        :return: Version tuple
+        :rtype: tuple
+        """
+        if self._output_version is not None:
+            return self._output_version
+        # Enforce distributed compose
+        return DEFAULT_VERSION
+
+    @output_version.setter
+    def output_version(self, version: Union[str, Tuple[int, int]]):
+        """
+        Set the version to use when serializing.
+
+        :param version: Version to use
+        :type version: str or tuple
+        """
+        self._output_version = get_version_tuple(version)
+
+    def detect_data_version(self, data: Dict[str, Any]) -> Tuple[int, int]:
+        """
+        Detect version from parsed data.
+
+        :param data: Parsed metadata
+        :type data: dict
+        :return: Version tuple
+        :rtype: tuple
+        """
+        return detect_version_from_data(data)
+
+    def should_use_locations(self) -> bool:
+        """
+        Check if Location objects should be used for output.
+
+        :return: True if using v2.0 format
+        :rtype: bool
+        """
+        return supports_location_objects(self.output_version)

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -1,0 +1,211 @@
+# -*- coding: utf-8 -*-
+
+import pytest
+
+from productmd.version import (
+    VERSION_1_0,
+    VERSION_1_1,
+    VERSION_1_2,
+    VERSION_2_0,
+    DEFAULT_VERSION,
+    detect_version_from_data,
+    is_v1,
+    is_v2,
+    version_to_string,
+    string_to_version,
+    get_version_tuple,
+    UnsupportedVersionError,
+)
+
+
+class TestVersionConstants:
+    """Tests for version constants."""
+
+    @pytest.mark.parametrize(
+        "constant,expected",
+        [
+            (VERSION_1_0, (1, 0)),
+            (VERSION_1_1, (1, 1)),
+            (VERSION_1_2, (1, 2)),
+            (VERSION_2_0, (2, 0)),
+        ],
+    )
+    def test_version_values(self, constant, expected):
+        """Test version constant values."""
+        assert constant == expected
+
+    @pytest.mark.parametrize(
+        "lower,higher",
+        [
+            (VERSION_1_0, VERSION_1_1),
+            (VERSION_1_1, VERSION_1_2),
+            (VERSION_1_2, VERSION_2_0),
+        ],
+    )
+    def test_version_ordering(self, lower, higher):
+        """Test version comparison."""
+        assert lower < higher
+
+    def test_default_version(self):
+        """Test default version is v2.0."""
+        assert DEFAULT_VERSION == VERSION_2_0
+
+
+class TestVersionConversion:
+    """Tests for version conversion utilities."""
+
+    @pytest.mark.parametrize(
+        "version_tuple,expected_string",
+        [
+            ((1, 0), "1.0"),
+            ((1, 2), "1.2"),
+            ((2, 0), "2.0"),
+            ((10, 5), "10.5"),
+        ],
+    )
+    def test_version_to_string(self, version_tuple, expected_string):
+        """Test converting version tuple to string."""
+        assert version_to_string(version_tuple) == expected_string
+
+    @pytest.mark.parametrize(
+        "version_string,expected_tuple",
+        [
+            ("1.0", (1, 0)),
+            ("1.2", (1, 2)),
+            ("2.0", (2, 0)),
+            ("10.5", (10, 5)),
+            ("2.0.3", (2, 0)),  # Ignore third version number
+        ],
+    )
+    def test_string_to_version(self, version_string, expected_tuple):
+        """Test converting version string to tuple."""
+        assert string_to_version(version_string) == expected_tuple
+
+    @pytest.mark.parametrize(
+        "invalid_string",
+        [
+            "invalid",
+            "1",
+            "2",
+            "a.b",
+            "",
+        ],
+    )
+    def test_string_to_version_invalid(self, invalid_string):
+        """Test invalid version string raises ValueError."""
+        with pytest.raises(ValueError):
+            string_to_version(invalid_string)
+
+    @pytest.mark.parametrize(
+        "version_input,expected",
+        [
+            ("2.0", (2, 0)),
+            ("1.2", (1, 2)),
+            ((2, 0), (2, 0)),
+            ((1, 2), (1, 2)),
+        ],
+    )
+    def test_get_version_tuple(self, version_input, expected):
+        """Test normalizing version to tuple."""
+        assert get_version_tuple(version_input) == expected
+
+
+class TestVersionChecks:
+    """Tests for version check utilities."""
+
+    @pytest.mark.parametrize(
+        "version,expected",
+        [
+            (VERSION_1_0, True),
+            (VERSION_1_1, True),
+            (VERSION_1_2, True),
+            (VERSION_2_0, False),
+            ("1.0", True),
+            ("1.2", True),
+            ("2.0", False),
+            ("0.1", False),
+            ((1, 5), True),
+            ((2, 1), False),
+        ],
+    )
+    def test_is_v1(self, version, expected):
+        """Test v1.x detection."""
+        assert is_v1(version) == expected
+
+    @pytest.mark.parametrize(
+        "version,expected",
+        [
+            (VERSION_1_0, False),
+            (VERSION_1_1, False),
+            (VERSION_1_2, False),
+            (VERSION_2_0, True),
+            ("1.2", False),
+            ("2.0", True),
+            ("0.1", False),
+            ((2, 1), True),
+            ((3, 0), False),  # v3.x is not v2.x
+            ("2.5", True),
+        ],
+    )
+    def test_is_v2(self, version, expected):
+        """Test v2.x detection (major version == 2)."""
+        assert is_v2(version) == expected
+
+
+class TestVersionDetection:
+    """Tests for version detection from metadata."""
+
+    @pytest.mark.parametrize(
+        "version_string,expected_tuple",
+        [
+            ("1.0", (1, 0)),
+            ("1.1", (1, 1)),
+            ("1.2", (1, 2)),
+            ("2.0", (2, 0)),
+        ],
+    )
+    def test_detect_version_from_data(self, version_string, expected_tuple):
+        """Test detecting version from data with header."""
+        data = {
+            "header": {"version": version_string, "type": "productmd.images"},
+            "payload": {"compose": {}, "images": {}},
+        }
+        assert detect_version_from_data(data) == expected_tuple
+
+    @pytest.mark.parametrize(
+        "invalid_data",
+        [
+            {"payload": {"compose": {}, "rpms": {}}},  # missing header
+            {"header": {"type": "productmd.images"}, "payload": {}},  # missing version
+            {"random": "data"},  # no header or payload
+            {"header": {"version": "a.b", "type": "productmd.images"}},
+            {},  # empty
+        ],
+    )
+    def test_detect_version_from_data_invalid(self, invalid_data):
+        """Test error on invalid data."""
+        with pytest.raises(ValueError):
+            detect_version_from_data(invalid_data)
+
+
+class TestUnsupportedVersionError:
+    """Tests for UnsupportedVersionError."""
+
+    def test_error_message(self):
+        """Test error message formatting."""
+        error = UnsupportedVersionError((3, 0))
+        assert "3.0" in str(error)
+        assert "Unsupported" in str(error)
+
+    def test_error_attributes(self):
+        """Test error attributes."""
+        error = UnsupportedVersionError((3, 0))
+        assert error.version == (3, 0)
+        assert (1, 2) in error.supported
+        assert (2, 0) in error.supported
+
+    def test_error_custom_supported(self):
+        """Test error with custom supported versions."""
+        custom_supported = [(1, 0), (2, 0)]
+        error = UnsupportedVersionError((3, 0), supported=custom_supported)
+        assert error.supported == custom_supported


### PR DESCRIPTION

* Introduce productmd.version module with utilities for detecting and handling metadata format versions
* Add support for `v1.x` (local compose) and `v2.0` (distributed compose) format detection
* Export version constants and utilities from the main productmd package


This PR introduces type hints in the new version module. This is an intentional decision to adopt gradual typing for new code (**not in tests**).