### PR TITLE
Unify rtd documentation theme for various branches

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -91,7 +91,7 @@ pygments_style = 'sphinx'
 
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
-html_theme = 'default'
+html_theme = 'sphinx_rtd_theme'
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the


### PR DESCRIPTION
Unify documentation theme under `shpinx_rtd_theme` for all documentation versions/revisions.

At the moment `latest` tracking master differs: https://productmd.readthedocs.io/en/latest/