### PR TITLE
Centralize `uv` version in `uv.toml`

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -24,9 +24,6 @@ jobs:
 
       - name: Install uv
         uses: astral-sh/setup-uv@v7
-        with:
-          version-file: ".python-version"
-          version: "0.9.26"
 
       - name: Build package
         run: uv build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,7 +46,6 @@ jobs:
         uses: astral-sh/setup-uv@v7
         with:
           python-version: ${{ matrix.python-version }}
-          version: "0.9.26" # uv version
           enable-cache: true
 
       - name: Install dependencies
@@ -91,8 +90,6 @@ jobs:
       - name: Install uv and Python interpreter
         uses: astral-sh/setup-uv@v7
         with:
-          version-file: ".python-version"
-          version: "0.9.26"
           enable-cache: true
 
       - name: Install dependencies
@@ -110,8 +107,6 @@ jobs:
       - name: Install uv and Python interpreter
         uses: astral-sh/setup-uv@v7
         with:
-          version-file: ".python-version"
-          version: "0.9.26"
           enable-cache: true
 
       - name: Install dependencies
@@ -129,8 +124,6 @@ jobs:
       - name: Install uv and Python interpreter
         uses: astral-sh/setup-uv@v7
         with:
-          version-file: ".python-version"
-          version: "0.9.26"
           enable-cache: true
 
       - name: Install dependencies

--- a/uv.toml
+++ b/uv.toml
@@ -1,0 +1,1 @@
+required-version = ">=0.9.26"


### PR DESCRIPTION
## Summary
- Add `uv.toml` with `required-version = ">=0.9.26"` so `setup-uv` reads the uv version from a single source instead of hardcoding it per workflow.
- Remove `version` and `version-file` from all `setup-uv` steps in `ci.yml` and `cd.yml`.