### PR TITLE
feat: add Rpms.get_location() public API for v2 location access

### DIFF
--- a/productmd/rpms.py
+++ b/productmd/rpms.py
@@ -316,3 +316,24 @@ class Rpms(productmd.common.MetadataBase, VersionedMetadataMixin):
         if location is not None:
             entry["_location"] = location
         rpms[nevra] = entry
+
+    def get_location(self, variant, arch, srpm_nevra, rpm_nevra):
+        """
+        Return the Location object for an RPM entry, or None.
+
+        :param variant:     compose variant UID
+        :type  variant:     str
+        :param arch:        compose architecture
+        :type  arch:        str
+        :param srpm_nevra:  name-epoch:version-release.arch of the SRPM
+        :type  srpm_nevra:  str
+        :param rpm_nevra:   name-epoch:version-release.arch of the RPM
+        :type  rpm_nevra:   str
+        :return: Location object, or None if not found or not set
+        :rtype: :class:`~productmd.location.Location` or None
+        """
+        try:
+            entry = self.rpms[variant][arch][srpm_nevra][rpm_nevra]
+        except KeyError:
+            return None
+        return entry.get("_location")

--- a/tests/test_rpms_v2.py
+++ b/tests/test_rpms_v2.py
@@ -265,10 +265,11 @@ class TestRpmsSerialization:
         assert rpm["category"] == "binary"
 
         # Location preserved for round-trip
-        assert rpm["_location"] is not None
-        assert isinstance(rpm["_location"], Location)
-        assert rpm["_location"].url == "https://cdn.example.com/bash-5.2.26-3.fc41.x86_64.rpm"
-        assert rpm["_location"].size == 1849356
+        loc = rpms.get_location("Server", "x86_64", "bash-0:5.2.26-3.fc41.src", "bash-0:5.2.26-3.fc41.x86_64")
+        assert loc is not None
+        assert isinstance(loc, Location)
+        assert loc.url == "https://cdn.example.com/bash-5.2.26-3.fc41.x86_64.rpm"
+        assert loc.size == 1849356
 
     @pytest.mark.parametrize(
         "version, header_version",
@@ -341,9 +342,10 @@ class TestRpmsRoundTrip:
         assert rpm["category"] == "binary"
 
         # Verify Location round-trip
-        assert rpm["_location"].url == "https://cdn.example.com/bash-5.2.26-3.fc41.x86_64.rpm"
-        assert rpm["_location"].size == 1849356
-        assert rpm["_location"].checksum == "sha256:" + "a" * 64
+        loc = rpms2.get_location("Server", "x86_64", "bash-0:5.2.26-3.fc41.src", "bash-0:5.2.26-3.fc41.x86_64")
+        assert loc.url == "https://cdn.example.com/bash-5.2.26-3.fc41.x86_64.rpm"
+        assert loc.size == 1849356
+        assert loc.checksum == "sha256:" + "a" * 64
 
     def test_v20_roundtrip_identity(self):
         """Test v2.0 serialize-deserialize-serialize produces identical output."""
@@ -447,8 +449,9 @@ class TestRpmsAddWithLocation:
 
         entry = rpms.rpms["Server"]["x86_64"]["bash-0:5.2.26-3.fc41.src"]["bash-0:5.2.26-3.fc41.x86_64"]
         assert entry["path"] == "Server/x86_64/os/Packages/b/bash-5.2.26-3.fc41.x86_64.rpm"
-        assert entry["_location"] is loc
-        assert entry["_location"].url == "https://cdn.example.com/Server/x86_64/os/Packages/b/bash-5.2.26-3.fc41.x86_64.rpm"
+        result = rpms.get_location("Server", "x86_64", "bash-0:5.2.26-3.fc41.src", "bash-0:5.2.26-3.fc41.x86_64")
+        assert result is loc
+        assert result.url == "https://cdn.example.com/Server/x86_64/os/Packages/b/bash-5.2.26-3.fc41.x86_64.rpm"
 
     def test_add_with_location_derives_path(self):
         """Test add() with location but path=None derives path from location.local_path."""
@@ -473,7 +476,8 @@ class TestRpmsAddWithLocation:
 
         entry = rpms.rpms["Server"]["x86_64"]["bash-0:5.2.26-3.fc41.src"]["bash-0:5.2.26-3.fc41.x86_64"]
         assert entry["path"] == "Server/x86_64/os/Packages/b/bash-5.2.26-3.fc41.x86_64.rpm"
-        assert entry["_location"] is loc
+        result = rpms.get_location("Server", "x86_64", "bash-0:5.2.26-3.fc41.src", "bash-0:5.2.26-3.fc41.x86_64")
+        assert result is loc
 
     def test_add_without_path_or_location_raises(self):
         """Test add() with path=None and no location raises ValueError."""

--- a/tests/test_rpms_v2.py
+++ b/tests/test_rpms_v2.py
@@ -642,3 +642,144 @@ class TestRpmsAddWithLocation:
 
         entry = rpms.rpms["Server"]["x86_64"]["bash-0:5.2.26-3.fc41.src"]["bash-0:5.2.26-3.fc41.x86_64"]
         assert "_location" not in entry
+
+
+class TestRpmsGetLocation:
+    """Tests for Rpms.get_location() public API."""
+
+    def test_get_location_after_add(self):
+        """get_location() returns the Location passed to add()."""
+        rpms = _create_rpms()
+        loc = Location(
+            url="https://cdn.example.com/bash-5.2.26-3.fc41.x86_64.rpm",
+            size=1849356,
+            checksum="sha256:" + "a" * 64,
+            local_path="Server/x86_64/os/Packages/b/bash-5.2.26-3.fc41.x86_64.rpm",
+        )
+        rpms.add(
+            "Server",
+            "x86_64",
+            "bash-0:5.2.26-3.fc41.x86_64",
+            path=None,
+            sigkey="a15b79cc",
+            category="binary",
+            srpm_nevra="bash-0:5.2.26-3.fc41.src",
+            location=loc,
+        )
+
+        result = rpms.get_location("Server", "x86_64", "bash-0:5.2.26-3.fc41.src", "bash-0:5.2.26-3.fc41.x86_64")
+        assert result is loc
+
+    def test_get_location_after_v2_deserialize(self):
+        """get_location() returns Location from deserialized v2 data."""
+        data = {
+            "header": {"type": "productmd.rpms", "version": "2.0"},
+            "payload": {
+                "compose": {
+                    "id": "Test-1.0-20240101.0",
+                    "date": "20240101",
+                    "type": "production",
+                    "respin": 0,
+                },
+                "rpms": {
+                    "Server": {
+                        "x86_64": {
+                            "bash-0:5.2.26-3.fc41.src": {
+                                "bash-0:5.2.26-3.fc41.x86_64": {
+                                    "location": {
+                                        "url": "https://cdn.example.com/bash-5.2.26-3.fc41.x86_64.rpm",
+                                        "size": 1849356,
+                                        "checksum": "sha256:" + "a" * 64,
+                                        "local_path": "Server/x86_64/os/Packages/b/bash-5.2.26-3.fc41.x86_64.rpm",
+                                    },
+                                    "sigkey": "a15b79cc",
+                                    "category": "binary",
+                                }
+                            }
+                        }
+                    }
+                },
+            },
+        }
+
+        rpms = Rpms()
+        rpms.deserialize(data)
+
+        result = rpms.get_location("Server", "x86_64", "bash-0:5.2.26-3.fc41.src", "bash-0:5.2.26-3.fc41.x86_64")
+        assert result is not None
+        assert isinstance(result, Location)
+        assert result.url == "https://cdn.example.com/bash-5.2.26-3.fc41.x86_64.rpm"
+        assert result.size == 1849356
+
+    def test_get_location_without_location_returns_none(self):
+        """get_location() returns None when RPM was added without a Location."""
+        rpms = _create_rpms()
+        rpms.add(
+            "Server",
+            "x86_64",
+            "bash-0:5.2.26-3.fc41.x86_64",
+            path="Server/x86_64/os/Packages/b/bash-5.2.26-3.fc41.x86_64.rpm",
+            sigkey="a15b79cc",
+            category="binary",
+            srpm_nevra="bash-0:5.2.26-3.fc41.src",
+        )
+
+        result = rpms.get_location("Server", "x86_64", "bash-0:5.2.26-3.fc41.src", "bash-0:5.2.26-3.fc41.x86_64")
+        assert result is None
+
+    def test_get_location_v1_deserialize_returns_none(self):
+        """get_location() returns None for v1.x deserialized data."""
+        data = {
+            "header": {"type": "productmd.rpms", "version": "1.2"},
+            "payload": {
+                "compose": {
+                    "id": "Test-1.0-20240101.0",
+                    "date": "20240101",
+                    "type": "production",
+                    "respin": 0,
+                },
+                "rpms": {
+                    "Server": {
+                        "x86_64": {
+                            "bash-0:5.2.26-3.fc41.src": {
+                                "bash-0:5.2.26-3.fc41.x86_64": {
+                                    "path": "Server/x86_64/os/Packages/b/bash-5.2.26-3.fc41.x86_64.rpm",
+                                    "sigkey": "a15b79cc",
+                                    "category": "binary",
+                                }
+                            }
+                        }
+                    }
+                },
+            },
+        }
+
+        rpms = Rpms()
+        rpms.deserialize(data)
+
+        result = rpms.get_location("Server", "x86_64", "bash-0:5.2.26-3.fc41.src", "bash-0:5.2.26-3.fc41.x86_64")
+        assert result is None
+
+    def test_get_location_missing_variant_returns_none(self):
+        """get_location() returns None for a non-existent variant."""
+        rpms = _create_rpms()
+        _add_sample_rpms(rpms)
+
+        result = rpms.get_location("NoSuchVariant", "x86_64", "bash-0:5.2.26-3.fc41.src", "bash-0:5.2.26-3.fc41.x86_64")
+        assert result is None
+
+    def test_get_location_missing_arch_returns_none(self):
+        """get_location() returns None for a non-existent arch."""
+        rpms = _create_rpms()
+        _add_sample_rpms(rpms)
+
+        result = rpms.get_location("Server", "aarch64", "bash-0:5.2.26-3.fc41.src", "bash-0:5.2.26-3.fc41.x86_64")
+        assert result is None
+
+    def test_get_location_missing_rpm_returns_none(self):
+        """get_location() returns None for a non-existent RPM NEVRA."""
+        rpms = _create_rpms()
+        _add_sample_rpms(rpms)
+
+        result = rpms.get_location("Server", "x86_64", "bash-0:5.2.26-3.fc41.src", "no-such-0:1.0-1.fc41.x86_64")
+        assert result is None


### PR DESCRIPTION
Add `Rpms.get_location(variant, arch, srpm_nevra, rpm_nevra)` public method to retrieve the `Location` object for an RPM entry, replacing the need to access the semi-private `_location` key directly.

Closes #250