### PR TITLE
chore: add workflow to sync dependabot PRs to development

### DIFF
--- a/.github/workflows/sync-to-development.yml
+++ b/.github/workflows/sync-to-development.yml
@@ -1,0 +1,68 @@
+# Sync to Development
+#
+# Cherry-picks merged dependabot PRs from master into the development branch.
+# Also posts a comment on new dependabot PRs to inform about the label.
+#
+# Usage:
+#   1. Create a "sync development" label in the GitHub repository.
+#   2. Add the label to a dependabot PR before merging.
+#   3. On merge, this workflow cherry-picks the commit into development.
+#
+# If the cherry-pick fails (e.g., due to conflicts), the workflow fails
+# and a notification is sent via the normal GitHub Actions failure alert.
+
+name: Sync to Development
+
+on:
+  pull_request:
+    branches:
+      - master
+    types: [opened, closed]
+
+jobs:
+  notify-sync-label:
+    if: >
+      github.event.action == 'opened' &&
+      github.actor == 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - name: Comment sync label availability
+        uses: actions/github-script@v7
+        with:
+          script: |
+            github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              body: 'Add the `sync development` label to this PR before merging to cherry-pick the changes into the `development` branch.'
+            })
+
+  sync-to-dev:
+    if: >
+      github.event.pull_request.merged == true &&
+      github.actor == 'dependabot[bot]' &&
+      contains(github.event.pull_request.labels.*.name, 'sync development')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Cherry-pick into development
+        run: |
+          git checkout development
+          git pull origin development
+          git cherry-pick ${{ github.event.pull_request.merge_commit_sha }}
+          git push origin development


### PR DESCRIPTION
## Summary
Add a GitHub Actions workflow that cherry-picks merged dependabot PRs from `master` into `development`.

### How it works
1. Triggered when a PR to `master` is merged.
2. Only runs if the PR was opened by `dependabot[bot]` and has the `sync development` label.
3. Cherry-picks the merge commit into the `development` branch and pushes it directly.
4. If the cherry-pick fails (e.g., due to conflicts), the workflow fails and sends the normal GitHub Actions failure notification.

### Usage
1. Create a `sync development` label in the repository.
2. Add the label to a dependabot PR before merging.
3. On merge, the workflow automatically cherry-picks the commit into `development`.