### PR TITLE
fix: check PR author instead of actor for dependabot detection

### DIFF
--- a/.github/workflows/sync-to-development.yml
+++ b/.github/workflows/sync-to-development.yml
@@ -23,7 +23,7 @@ jobs:
   notify-sync-label:
     if: >
       github.event.action == 'opened' &&
-      github.actor == 'dependabot[bot]'
+      github.event.pull_request.user.login == 'dependabot[bot]'
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write
@@ -42,7 +42,7 @@ jobs:
   sync-to-dev:
     if: >
       github.event.pull_request.merged == true &&
-      github.actor == 'dependabot[bot]' &&
+      github.event.pull_request.user.login == 'dependabot[bot]' &&
       contains(github.event.pull_request.labels.*.name, 'sync development')
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
Use `github.event.pull_request.user.login` instead of `github.actor` to detect dependabot PRs. `github.actor` reflects who merged the PR (the human reviewer), not who opened it (dependabot), causing the sync job to be skipped.