### PR TITLE
Add Codecov coverage reporting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,13 @@ jobs:
     container:
       image: fedora:latest
 
+    permissions:
+      id-token: write  # Required for Codecov OIDC authentication
+
     steps:
+      - name: Install git-core
+        run: dnf install -y git-core
+
       - uses: actions/checkout@v6
 
       - name: Install uv and setup Python version
@@ -49,10 +55,18 @@ jobs:
           enable-cache: true
 
       - name: Install dependencies
-        run: uv sync --group test --no-dev
+        run: uv sync --group test --group coverage --no-dev
 
       - name: Run tests
-        run: uv run pytest tests
+        run: uv run pytest tests --cov=productmd --cov-report=xml:coverage.xml
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          use_oidc: true
+          flags: unit-tests
+          files: coverage.xml
+          fail_ci_if_error: false
 
   test-py36:
     needs: [lint, format, bandit]

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,29 @@
+codecov:
+  require_ci_to_pass: yes
+
+coverage:
+  precision: 2
+  round: down
+  range: "50...100"
+
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 1%
+    patch:
+      default:
+        target: auto
+        threshold: 1%
+
+flags:
+  unit-tests:
+    carryforward: true
+
+comment:
+  layout: "reach,diff,flags,files"
+  behavior: default
+
+ignore:
+  - "doc/**"
+  - "tests/**"


### PR DESCRIPTION
- Run pytest with --cov to generate coverage.xml
- Upload coverage to Codecov via OIDC (no token required)
- Use unit-tests flag for coverage categorization
- Add codecov.yml with thresholds and flag configuration